### PR TITLE
copy implementation from ember-cli and convert to commander

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/index.js
+++ b/index.js
@@ -1,0 +1,114 @@
+import { program, Option } from 'commander';
+import { join } from 'node:path';
+import fs from 'node:fs';
+import npmPackageArg from 'npm-package-arg';
+import _latestVersion from 'latest-version';
+import { readFile } from 'node:fs/promises';
+
+const pkg = JSON.parse(await readFile(join(import.meta.dirname, 'package.json'), 'utf8'));
+
+program
+  .name(pkg.name)
+  .version(pkg.version)
+  .addHelpText('after', `
+
+Examples:
+
+  node dev/update-blueprint-dependencies.js --ember-source=beta --ember-data=beta
+  node dev/update-blueprint-dependencies.js --filter /eslint/
+  node dev/update-blueprint-dependencies.js --filter some-package@beta
+`)
+  .description('This script updates the dependencies / devDependencies in package.json files and is tolerant of EJS templates')
+  .requiredOption('--ember-source <dist-tag>', 'The dist-tag to use for ember-source')
+  .requiredOption('--ember-data <dist-tag>', 'The dist-tag to use for ember-data')
+  .option('--ember-cli <dist-tag>', 'The dist-tag to use for ember-cli')
+  .addOption(new Option('--filter <regex>', 'A RegExp to filter the packages to update by').argParser((value) => new RegExp(value)))
+  .option('--latest', `Always use the latest version available for a package (includes major bumps, 'false' by default)`)
+  .argument('<files...>', 'package.json files to update');
+
+program.parse();
+
+const OPTIONS = program.opts();
+
+const PACKAGE_FILES = program.args;
+
+function shouldCheckDependency(dependency) {
+  if (OPTIONS.filter) {
+    return OPTIONS.filter.test(dependency);
+  }
+
+  return true;
+}
+
+const LATEST = new Map();
+async function latestVersion(packageName, semverRange) {
+  let result = LATEST.get(packageName);
+
+  if (result === undefined) {
+    let options = {
+      version: semverRange,
+    };
+
+    if (OPTIONS[packageName]) {
+      options.version = OPTIONS[packageName];
+    }
+
+    result = _latestVersion(packageName, options);
+    LATEST.set(packageName, result);
+  }
+
+  return result;
+}
+
+async function updateDependencies(dependencies) {
+  for (let dependencyKey in dependencies) {
+    let dependencyName = removeTemplateExpression(dependencyKey);
+
+    if (!shouldCheckDependency(dependencyName)) {
+      continue;
+    }
+
+    let previousValue = dependencies[dependencyKey];
+
+    // grab the first char (~ or ^)
+    let prefix = previousValue[0];
+    let isValidPrefix = prefix === '~' || prefix === '^';
+
+    // handle things from blueprints/app/files/package.json like `^2.4.0<% if (welcome) { %>`
+    let templateSuffix = previousValue.includes('<') ? previousValue.slice(previousValue.indexOf('<')) : '';
+
+    // check if we are dealing with `~<%= emberCLIVersion %>`
+    let hasVersion = previousValue[1] !== '<';
+
+    if (hasVersion && isValidPrefix) {
+      const semverRange = OPTIONS.latest ? 'latest' : removeTemplateExpression(previousValue);
+      const newVersion = await latestVersion(dependencyName, semverRange);
+
+      dependencies[dependencyKey] = `${prefix}${newVersion}${templateSuffix}`;
+    }
+  }
+}
+
+function removeTemplateExpression(dependency) {
+  if (dependency.includes('<') === false) {
+    return dependency;
+  }
+
+  let semverRange = dependency.replace(
+    dependency.substring(dependency.indexOf('<'), dependency.lastIndexOf('>') + 1),
+    ''
+  );
+
+  return semverRange;
+}
+
+for (let filePath of PACKAGE_FILES) {
+  let pkg = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf8' }));
+
+  await updateDependencies(pkg.dependencies);
+  await updateDependencies(pkg.devDependencies);
+
+  let output = `${JSON.stringify(pkg, null, 2)}\n`;
+
+  fs.writeFileSync(filePath, output, { encoding: 'utf8' });
+}

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "license": "MIT",
   "packageManager": "pnpm@10.11.0",
   "dependencies": {
+    "commander": "^14.0.0",
+    "latest-version": "^9.0.0",
+    "npm-package-arg": "^12.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,188 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      commander:
+        specifier: ^14.0.0
+        version: 14.0.0
+      latest-version:
+        specifier: ^9.0.0
+        version: 9.0.0
+      npm-package-arg:
+        specifier: ^12.0.2
+        version: 12.0.2
+
+packages:
+
+  '@pnpm/config.env-replace@1.1.0':
+    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/network.ca-file@1.0.2':
+    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/npm-conf@2.3.1':
+    resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
+    engines: {node: '>=12'}
+
+  commander@14.0.0:
+    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+    engines: {node: '>=20'}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+
+  hosted-git-info@8.1.0:
+    resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ky@1.8.1:
+    resolution: {integrity: sha512-7Bp3TpsE+L+TARSnnDpk3xg8Idi8RwSLdj6CMbNWoOARIrGrbuLGusV0dYwbZOm4bB3jHNxSw8Wk/ByDqJEnDw==}
+    engines: {node: '>=18'}
+
+  latest-version@9.0.0:
+    resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
+    engines: {node: '>=18'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  npm-package-arg@12.0.2:
+    resolution: {integrity: sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  package-json@10.0.1:
+    resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
+    engines: {node: '>=18'}
+
+  proc-log@5.0.0:
+    resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  registry-auth-token@5.1.0:
+    resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
+    engines: {node: '>=14'}
+
+  registry-url@6.0.1:
+    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
+    engines: {node: '>=12'}
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  validate-npm-package-name@6.0.0:
+    resolution: {integrity: sha512-d7KLgL1LD3U3fgnvWEY1cQXoO/q6EQ1BSz48Sa149V/5zVTAbgmZIpyI8TRi6U9/JNyeYLlTKsEMPtLC27RFUg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+snapshots:
+
+  '@pnpm/config.env-replace@1.1.0': {}
+
+  '@pnpm/network.ca-file@1.0.2':
+    dependencies:
+      graceful-fs: 4.2.10
+
+  '@pnpm/npm-conf@2.3.1':
+    dependencies:
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
+      config-chain: 1.1.13
+
+  commander@14.0.0: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
+  deep-extend@0.6.0: {}
+
+  graceful-fs@4.2.10: {}
+
+  hosted-git-info@8.1.0:
+    dependencies:
+      lru-cache: 10.4.3
+
+  ini@1.3.8: {}
+
+  ky@1.8.1: {}
+
+  latest-version@9.0.0:
+    dependencies:
+      package-json: 10.0.1
+
+  lru-cache@10.4.3: {}
+
+  minimist@1.2.8: {}
+
+  npm-package-arg@12.0.2:
+    dependencies:
+      hosted-git-info: 8.1.0
+      proc-log: 5.0.0
+      semver: 7.7.2
+      validate-npm-package-name: 6.0.0
+
+  package-json@10.0.1:
+    dependencies:
+      ky: 1.8.1
+      registry-auth-token: 5.1.0
+      registry-url: 6.0.1
+      semver: 7.7.2
+
+  proc-log@5.0.0: {}
+
+  proto-list@1.2.4: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  registry-auth-token@5.1.0:
+    dependencies:
+      '@pnpm/npm-conf': 2.3.1
+
+  registry-url@6.0.1:
+    dependencies:
+      rc: 1.2.8
+
+  semver@7.7.2: {}
+
+  strip-json-comments@2.0.1: {}
+
+  validate-npm-package-name@6.0.0: {}


### PR DESCRIPTION
This copies the implementation from https://github.com/ember-cli/ember-cli/blob/cb524c1f7bcb94f3610e7e3ae6df7c9d469b456c/dev/update-blueprint-dependencies.js and updates it to use commander.