### PR TITLE
replace latest-version with our own function that has a minimum age for packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import { program, Option } from 'commander';
 import { join } from 'node:path';
 import fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { getLatestVersion } from './lib/latest-version';
+import { getLatestVersion } from './lib/latest-version.js';
 
 const pkg = JSON.parse(
   await readFile(join(import.meta.dirname, 'package.json'), 'utf8'),

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 import { program, Option } from 'commander';
 import { join } from 'node:path';
 import fs from 'node:fs';
-import _latestVersion from 'latest-version';
 import { readFile } from 'node:fs/promises';
+import { getLatestVersion } from './lib/latest-version';
 
 const pkg = JSON.parse(
   await readFile(join(import.meta.dirname, 'package.json'), 'utf8'),
@@ -68,26 +68,6 @@ export default async function main(argv) {
     return true;
   }
 
-  const LATEST = new Map();
-  async function latestVersion(packageName, semverRange) {
-    let result = LATEST.get(packageName);
-
-    if (result === undefined) {
-      let options = {
-        version: semverRange,
-      };
-
-      if (OPTIONS[packageName]) {
-        options.version = OPTIONS[packageName];
-      }
-
-      result = _latestVersion(packageName, options);
-      LATEST.set(packageName, result);
-    }
-
-    return result;
-  }
-
   async function updateDependencies(dependencies) {
     for (let dependencyKey in dependencies) {
       let dependencyName = removeTemplateExpression(dependencyKey);
@@ -116,7 +96,11 @@ export default async function main(argv) {
           : removeTemplateExpression(previousValue);
         let newVersion;
         try {
-          newVersion = await latestVersion(dependencyName, semverRange);
+          newVersion = await getLatestVersion(
+            dependencyName,
+            semverRange,
+            OPTIONS.tag,
+          );
 
           dependencies[dependencyKey] =
             `${prefix}${newVersion}${templateSuffix}`;

--- a/lib/latest-version.js
+++ b/lib/latest-version.js
@@ -1,0 +1,71 @@
+import { view } from '@pnpm/deps.inspection.commands';
+import { getConfig } from '@pnpm/config.reader';
+import { packageManager } from '@pnpm/cli.meta';
+import semver from 'semver';
+import 'temporal-polyfill/global';
+
+const { config, context } = await getConfig({
+  cliOptions: {},
+  packageManager,
+});
+
+/**
+ * This function is used to get the latest version of a package that is in-range for the specified semverRange. There is a built-in
+ * implementation for minimum package age to prevent you forcing an update to a compromised npm package. For the use-case of this
+ * function it would be a small window that you would need to be compromised but better safe than sorry!
+ *
+ * @param {string} dependencyName - npm dependency
+ * @param {string} semverRange - a valid semver range that can be passed directly to the semver package
+ * @param {string} [tag] - if passed it will pick the relevant dist-tag from npm instead of reading semverRange
+ * @returns {string|undefined} the updated version in range or undefined if tag requested and the tag is missing from dist-tags
+ */
+export async function getLatestVersion(dependencyName, semverRange, tag) {
+  if (tag) {
+    const distTags = JSON.parse(
+      await view.handler({ config, context, registries: config.registries }, [
+        dependencyName,
+        'dist-tags',
+      ]),
+    );
+
+    if (!distTags[tag]) {
+      console.warn(`No tag ${tag} found for ${dependencyName}`);
+      return;
+    }
+
+    return distTags[tag];
+  }
+
+  const timeResults = JSON.parse(
+    await view.handler({ config, context, registries: config.registries }, [
+      dependencyName,
+      'time',
+    ]),
+  );
+
+  const filteredResults = Object.entries(timeResults).filter(
+    ([version, datestring]) => {
+      if (!semver.satisfies(version, semverRange)) {
+        return false;
+      }
+
+      const now = Temporal.Now.instant();
+      const releaseTime = Temporal.Instant.from(datestring);
+
+      const duration = releaseTime.until(now);
+
+      if (
+        Temporal.Duration.compare(
+          duration,
+          Temporal.Duration.from({ days: 7 }),
+        ) < 0
+      ) {
+        return false;
+      }
+
+      return true;
+    },
+  );
+
+  return filteredResults.at(-1)[0];
+}

--- a/lib/latest-version.js
+++ b/lib/latest-version.js
@@ -43,6 +43,8 @@ export async function getLatestVersion(dependencyName, semverRange, tag) {
     ]),
   );
 
+  const minimumDaysOld = 7;
+
   const filteredResults = Object.entries(timeResults).filter(
     ([version, datestring]) => {
       if (!semver.satisfies(version, semverRange)) {
@@ -57,7 +59,7 @@ export async function getLatestVersion(dependencyName, semverRange, tag) {
       if (
         Temporal.Duration.compare(
           duration,
-          Temporal.Duration.from({ days: 7 }),
+          Temporal.Duration.from({ days: minimumDaysOld }),
         ) < 0
       ) {
         return false;
@@ -66,6 +68,14 @@ export async function getLatestVersion(dependencyName, semverRange, tag) {
       return true;
     },
   );
+
+  if (filteredResults.length === 0) {
+    console.warn(
+      `There are no versions that match range "${semverRange}" for "${dependencyName}" that are older than ${minimumDaysOld} days`,
+    );
+    console.warn('skipping this package');
+    return;
+  }
 
   return filteredResults.at(-1)[0];
 }

--- a/package.json
+++ b/package.json
@@ -26,13 +26,16 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@pnpm/cli.meta": "^1100.0.3",
+    "@pnpm/config.reader": "^1101.3.0",
+    "@pnpm/deps.inspection.commands": "^1100.2.1",
     "commander": "^14.0.0",
-    "latest-version": "^9.0.0"
+    "temporal-polyfill": "^0.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",
     "concurrently": "^9.1.2",
-    "eslint": "^9.27.0",
+    "eslint": "^10.3.0",
     "fixturify-project": "^7.1.3",
     "globals": "^16.1.0",
     "prettier": "^3.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@pnpm/cli.meta':
+        specifier: ^1100.0.3
+        version: 1100.0.3
+      '@pnpm/config.reader':
+        specifier: ^1101.3.0
+        version: 1101.3.0(@pnpm/logger@5.2.0)
+      '@pnpm/deps.inspection.commands':
+        specifier: ^1100.2.1
+        version: 1100.2.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(@yarnpkg/core@4.7.0(typanion@3.14.0))(ts-toolbelt@9.6.0)(typanion@3.14.0)
       commander:
         specifier: ^14.0.0
         version: 14.0.0
-      latest-version:
-        specifier: ^9.0.0
-        version: 9.0.0
+      temporal-polyfill:
+        specifier: ^0.3.2
+        version: 0.3.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.27.0
@@ -22,8 +31,8 @@ importers:
         specifier: ^9.1.2
         version: 9.1.2
       eslint:
-        specifier: ^9.27.0
-        version: 9.27.0
+        specifier: ^10.3.0
+        version: 10.3.0
       fixturify-project:
         specifier: ^7.1.3
         version: 7.1.3
@@ -41,9 +50,12 @@ importers:
         version: 7.7.2
       vitest:
         specifier: ^3.1.4
-        version: 3.1.4(@types/node@22.15.21)
+        version: 3.1.4(@types/node@22.15.21)(yaml@2.9.0)
 
 packages:
+
+  '@arcanis/slice-ansi@1.1.1':
+    resolution: {integrity: sha512-xguP2WR2Dv0gQ7Ykbdb7BNCnPnIPB94uTi0Z2NvkRBEnhbwjOQ7QyQKJXrVQg4qDpiD9hA5l5cCwy/z2OXgc3w==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -207,43 +219,39 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.7.0':
-    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.20.0':
-    resolution: {integrity: sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.2.2':
-    resolution: {integrity: sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/core@0.14.0':
-    resolution: {integrity: sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/eslintrc@3.3.1':
-    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/js@9.27.0':
     resolution: {integrity: sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/object-schema@2.1.6':
-    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/plugin-kit@0.3.1':
-    resolution: {integrity: sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -276,8 +284,15 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@lazy-node/types-path@1.0.3':
+    resolution: {integrity: sha512-5Bnl5s5jh7o14i0oa7gj+Y0fDLIlri3+KVZmv4gk0OFGuOrOEmWBBCI9ky3Syip5g/yPHZdfa+WO5BVJMUpMdw==}
 
   '@manypkg/find-root@2.2.3':
     resolution: {integrity: sha512-jtEZKczWTueJYHjGpxU3KJQ08Gsrf4r6Q2GjmPp/RGk5leeYAA1eyDADSAF+KVCsQ6EwZd/FMcOFCoMhtqdCtQ==}
@@ -291,6 +306,36 @@ packages:
     resolution: {integrity: sha512-3lBouSuF7CqlseLB+FKES0K4FQ02JrbEoRtJhxnsyB1s5v4AP03gsoohN8jp7DcOImhaR9scYdztq3/sLfk/qQ==}
     engines: {node: '>=14.18.0'}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -303,8 +348,16 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@npmcli/agent@3.0.0':
+    resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   '@npmcli/fs@1.1.1':
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+
+  '@npmcli/fs@4.0.0':
+    resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   '@npmcli/git@6.0.3':
     resolution: {integrity: sha512-GUYESQlxZRAdhs3UhbB6pVRNUELQOHXwK9ruDkwmCv2aZ5y0SApQzUJCg02p3A7Ue2J5hxvlk1YI53c00NmRyQ==}
@@ -385,6 +438,71 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@pnpm/agent.client@1.0.4':
+    resolution: {integrity: sha512-1A6hlCrFDQMMj615rC7RkL62dwcO04o6QHtmCprM9mP2ya9zI1wTemuACedJnJByRXAtYIZcM1RmgFJC0NawNA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/bins.linker@1100.0.5':
+    resolution: {integrity: sha512-bgrFdW/4qdXFUWdMNlaZC5UJgMLiwPxzGqfVGVcxfMKLuuA7aA8gj77v+pLzMyby0eW2tTk6x77C74O4RqpcqQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/bins.remover@1100.0.3':
+    resolution: {integrity: sha512-/saDlpltnFN6b3J9aqfzCl+zAJBY7NS/F+reorUlAgeKjhinVkm5bIrYVIE70b4MTsANwUfBRKWhwvkk8lZyJQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/bins.resolver@1100.0.3':
+    resolution: {integrity: sha512-ksLh1CDGK9vlWyQvN860Rg9Y4++xK06Ruo5N4euri/MsshL2TA/Imgxyym9rfTyYYWMKPmjVRv5gnjJKv+nXTw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/building.after-install@1101.0.11':
+    resolution: {integrity: sha512-nAUFuH+2XOxXt3xFMpogyYHgzRu0CdFL6TJM8gsxr95s++eIy26IRbrmZQVulSsNf2DUFXoFZC0efxRIPf7KQA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/building.during-install@1101.0.9':
+    resolution: {integrity: sha512-iIjj9TgWBe3PaLeagvljTHizWXZYIwR1N40LA3tRlngg2yd5fiQZhlWTMD9u3Kqi6VLXgifaOqYLEN3KLEttrQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/building.pkg-requires-build@1100.0.3':
+    resolution: {integrity: sha512-NLkLXF8xXxQ+UpJQTQw87sfqWBkyFTpWyQd6bDYQcEeyS+byblIxeUiHI6x2RZSmJO3zRvSbXPxgyhcUboszzA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/building.policy@1100.0.4':
+    resolution: {integrity: sha512-qlrlqKURh/orL7AiKwKbsPxXEr4c5q+3n31q4kAm6PqoR3a8HYZDk5gjY+4gCmWpnxiJtvAXJYLHv+wt6RIIVg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/byline@1.0.0':
+    resolution: {integrity: sha512-61tmh+k7hnKK6b2XbF4GvxmiaF3l2a+xQlZyeoOGBs7mXU3Ie8iCAeAnM0+r70KiqTrgWvBCjMeM+W3JarJqaQ==}
+    engines: {node: '>=12.17'}
+
+  '@pnpm/catalogs.config@1100.0.0':
+    resolution: {integrity: sha512-m6w7+/q9BAyEvlJEuuu4DX6cnFQnCbcsED6AB4AJlz+Nw0UQ/Tas1QOmH1EQ1skM+s+Un1nEQO7D61HG8w3LYw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/catalogs.protocol-parser@1100.0.0':
+    resolution: {integrity: sha512-PZ5dC9QBdsZVxIOdk3sgZkLurCzv7Jx5PGmk8xsBFLYljC8qIgSblayxz+1BReIICmDgGhKQffth55u8tH6qUA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/catalogs.resolver@1100.0.0':
+    resolution: {integrity: sha512-LTJjBuALdsjWrBO5l7Pw3Cv+gNX46yWwvyoHyAslBuGy7yOQ5D4L+eT4AYEdOAsG6rFs2H5WIem2L1ZdkApvwg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/catalogs.types@1100.0.0':
+    resolution: {integrity: sha512-TE37v+2rxFeLVVDcbeK8a2jWqQ/dugYnQZ72++ipj5fq807qqdBn6jePVz/CL+bcuA+YSYejFejDNmyq9Jb45A==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/cli-meta@6.0.1':
     resolution: {integrity: sha512-r1mAyn8wCD5Ow89sF/5IfdwaXyzWI0bI2SVHA8/dR/+ykylCA7L05PKkvV6LSEQ28eKEawNq/0OwnxRSjVx9BQ==}
     engines: {node: '>=18.12'}
@@ -395,6 +513,28 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^5.0.0
 
+  '@pnpm/cli.command@1100.0.1':
+    resolution: {integrity: sha512-hP9POIGbdLk9wTSnOeRkpb8YdZyQlXMHIz14OW6EGVHgSSGYg0YwyKjE+k52ImiMfL8GsmtK9s1VxzS0d7Sp6w==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/cli.common-cli-options-help@1100.0.1':
+    resolution: {integrity: sha512-0pjvtJqHrM6BPNjyUY9WsvGCSoqqXVIVvjOEw1Yu1k0bizyw1zSDk8l7ym962oFOqeHVq7FcO9zSIJ7mk+cn/w==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/cli.meta@1100.0.3':
+    resolution: {integrity: sha512-l61bFf0DTebgGov4LbWeJeVJv8rA8qTdE0nXJcV0E96UaUJdQYelbsVTHXnknltgRHXkwEGs1HVleoci7TYPdQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/cli.utils@1101.0.3':
+    resolution: {integrity: sha512-usNJ/DiNEpH13XlESgyOOqHugk5ZQhWujhP94FKDEbWu+Anjy8nuemTS+V+WN481+je6ZS6mfSJiJgLdQbxLow==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/colorize-semver-diff@2.0.0':
+    resolution: {integrity: sha512-rdzxBK0DRDWKXNrkNL+jvzKm5BGuNqQOGYe/1QpJQhaBd6tmXwkQmbcKm18CJI9qQJFrPH2KZ/99cNhpwYPqvg==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
@@ -403,6 +543,46 @@ packages:
     resolution: {integrity: sha512-tV71wOtu8ULW4Fv5c7MWph3Sfle1wkT2q83qF2Cx/0J5E2dpUsClO9evAouL4fbdmPonkXJbRYL5cGHKuqxr4w==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/config.env-replace@3.0.2':
+    resolution: {integrity: sha512-GD6nKLyKF+ev15Tj3pS8y6cTVPIuAqTyhPrUFMfmodFvhEDdYKN/gdGimkc9GJLfHVC/SuCVFg49YNJyoW7niA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/config.matcher@1100.0.1':
+    resolution: {integrity: sha512-pW20KKYeI61nshCUa6QBGh4Zuwu2CgDmdzJ/7nI7jZAgfDqpLR55MMhgGJRbNfChF0H9p7SdmRrZu0GrHfMqVQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/config.nerf-dart@1.0.1':
+    resolution: {integrity: sha512-03d2l21gAyzGVr9SR6rS5pvCTnZ4HaNdi8jB2Y/UGvszzrNbA+AJVObVw6SulNQ1Eah3SHB9wCezJwtP+jYIcA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/config.normalize-registries@1100.0.3':
+    resolution: {integrity: sha512-Rg2EktFzi7pdUbng+TJ6bhbcCkku9TTfjBxZxAsSjOcVnpW1h8ilk5ECiHj+sOgbtD/sFFvoj9JGK2ys5IdtcA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/config.package-is-installable@1100.0.4':
+    resolution: {integrity: sha512-2Sswj7bGmaPLv38tSliTuAiFNkD3us/QJ9z7pXGdb7tPZbNxL/haaOD5JeWo28uKaJgedXn95ZcQVTLV0AZX8w==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/config.parse-overrides@1100.0.1':
+    resolution: {integrity: sha512-nGp29EW2hk+sR+6GSp4GoeH5q5IRAxphzX9Tn5TZeZf9ZzQ/DJvF8UrvAzVGWnixSUlTu/2BF9xpmU8lJoA8aQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/config.pick-registry-for-package@1100.0.3':
+    resolution: {integrity: sha512-kYmeOounh7k1/xmHu2IeiZc/j8PUNy5nrMnybyjV2w5rFe/25poZQFvr/G0IEHjh4Ayvt0DmwISGDCRcGpa/Lw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/config.reader@1101.3.0':
+    resolution: {integrity: sha512-gk9HENZQCWr/St7wbtcuuFppa9m/0Pr2v1oM/DeFKFeuneuGy06v2F4z1NhI/PUU2AJ6vOBRllN6uEz5FIp90w==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/config.version-policy@1100.0.3':
+    resolution: {integrity: sha512-1wjp0G11kKcd49CdmV0KJaFfTjypzQTbGlR5njAA2Ya5Blh3P2H0Qj/3bD9j1aY/a5MTF4Z7lj9SR6bfRMUI0g==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/config@21.4.0':
     resolution: {integrity: sha512-SrER4w4eICWd/LdjRkLjleu0aeMVo1exB2AOl5XcFS5yTxWwnkWNGq9ngL8+q7RS/HJA0+A8FJnZkatW2WbK4A==}
     engines: {node: '>=18.12'}
@@ -410,6 +590,14 @@ packages:
   '@pnpm/constants@10.0.0':
     resolution: {integrity: sha512-dxIXcW1F1dxIGfye2JXE7Q8WVwYB0axVzdBOkvE1WKIVR4xjB8e6k/Dkjo7DpbyfW5Vu2k21p6dyM32YLSAWoQ==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/constants@1001.3.1':
+    resolution: {integrity: sha512-2hf0s4pVrVEH8RvdJJ7YRKjQdiG8m0iAT26TTqXnCbK30kKwJW69VLmP5tED5zstmDRXcOeH5eRcrpkdwczQ9g==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/constants@1100.0.0':
+    resolution: {integrity: sha512-CSJ5fKSUgqXrON5J2zQd1LwttU4gdqffJ3zYyHGAEhZ8u22fhQEVfCnc4+3aczDHbBNU0pNRX2ajiioPj46YtA==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/constants@8.0.0':
     resolution: {integrity: sha512-yQosGUvYPpAjb1jOFcdbwekRjZRVxN6C0hHzfRCZrMKbxGjt/E0g0RcFlEDNVZ95tm4oMMcr7nEPa7H7LX3emw==}
@@ -421,9 +609,31 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^5.0.0
 
+  '@pnpm/core-loggers@1100.0.2':
+    resolution: {integrity: sha512-punfGxCYbkYpWC2Nb7SlhMKXbUk9oiW17vPurOxQP7h6LAuaZ4C2F4/UxmLOS926+rQAA+DvNCVProNLomocFA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
   '@pnpm/crypto.base32-hash@3.0.0':
     resolution: {integrity: sha512-iGKP6rRKng5Tcad1+S+j3UoY5wVZN+z0ZgemlGp69jNgn6EaM4N0Q3mvnDNJ7UZFmL2ClXZZYLNuCk9pUYV3Xg==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/crypto.hash@1100.0.1':
+    resolution: {integrity: sha512-Zq7m0/2wT/9BgXtk0ue5OC6MeHk+KpbDICmSKybeSy7NQ7sWreiDXhRBnipRLDo21vY7nLuXRsRLopk+3cCmoQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/crypto.integrity@1100.0.0':
+    resolution: {integrity: sha512-trwmDQHIuuhgD15yMBLLSNvjrVElq/IpRZ6UqO7oGsPlX7ABgLOeujc+iDLunnpSUb+OOr0NDlT137nm52EJ/Q==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/crypto.object-hasher@1100.0.0':
+    resolution: {integrity: sha512-56Cph/2xkVjy8AkKUjQmhXO1Ko8nunIomjBjtZJco6S/6//unU1COEyEajEAb9NWxHVtXGSC1kK0skE1hMWjrA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/crypto.shasums-file@1100.0.1':
+    resolution: {integrity: sha512-INE0i2V7yXTf2tHJrTWKJEOhmfpCufo7HXkm8qiFq01b9fqsbGu24phrTGYBaYNYBTac9EwiVMzn1nByrFRl0g==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/dedupe.issues-renderer@2.0.0':
     resolution: {integrity: sha512-UFKcCGUtL+2vbjXPCdw5H3Y/xj6iqVS86ChJSZj6GVODNR+gWO9j0HYMYVBFiQVOIm/7p86Rudyrm3cxmIEmWw==}
@@ -439,6 +649,84 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^5.0.0
 
+  '@pnpm/deps.graph-builder@1100.0.8':
+    resolution: {integrity: sha512-5gzaVRmwHh1XK4NiaP38lPyjsaqs9QumyeJ7wFhBn3hBUcycXVtK3T6Z89RH07kcVdSHlLmuG/nAvnUHJMaLXw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/deps.graph-hasher@1100.1.5':
+    resolution: {integrity: sha512-f26DAOgr++p2fuZlPzNvMXIy1MlBGK0XqG0N6wfoM0AchxHeRRTR020QsZ0MOAVHBIJvtsQ71MpE2ZOBs/z6Hg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/deps.graph-sequencer@1100.0.0':
+    resolution: {integrity: sha512-IfhLdXMjNaAt2Z/r0hAqMvH4UN/Eb6LAbnSHqF9Ay1EhQId8rFX58yIWXLUit6VjJTJAptnSPtO8nSu2/ggQsg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/deps.inspection.commands@1100.2.1':
+    resolution: {integrity: sha512-tcnbbyrHrP8UeiEBP2Zym6LQBchmtBCq84BT8q2WoqvjEubdfKQ4w1qPq0dNs5jxO/EIDzC6PhcIvfLr/F+biQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/deps.inspection.list@1100.0.9':
+    resolution: {integrity: sha512-AmQbVLLAmELVvFM5ue0yfXZEWpUvduuAYMYQ3MX7NATS2BGXxwGd7bgon9MWEqaj4GZP0pmCmJClr5RM3CjwAg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/deps.inspection.outdated@1100.0.14':
+    resolution: {integrity: sha512-2tn6FbKvgnBdC//wWUySL5/qEb+klqOWuKrCCATzwVljGvqo6lattcJ2ewbDE/Vodb0KLAGqKuHAEt3nQbOzaQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/deps.inspection.peers-checker@1100.0.7':
+    resolution: {integrity: sha512-cRR2159NCDpMhP7IR17ygjok6VckQd23H18oMoZWzCanF3qB5zIs0a8sX7Z+MjRhfAwVHofWVAMZj7AFM/2fMA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/deps.inspection.peers-issues-renderer@1100.0.1':
+    resolution: {integrity: sha512-MygmyaTjOoeeWjfyN/3B6ff7gNnB0Gz7yp5nxZWebI+IdmHsK/m42SVwzQ8ZUbZPaQ3nnr8VQ2fK3faSHLHyQw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/deps.inspection.tree-builder@1100.0.8':
+    resolution: {integrity: sha512-KB+IGcItQWEslC3gsAAsl9J3qh4wxKdEp4/S/r/iflv09MvRaEKLJ128YEhRizAOpJWHzq3YKZcJa4AjuBce8w==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/deps.path@1100.0.3':
+    resolution: {integrity: sha512-kppGx/qLad54Pf1bJtEy6QL+g0FjUBcl12aYZ2pcvOoITcY6Zsk/ZDo2o9Bn2aBGPbIu+XdepAf95ppW5vfxRQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/deps.peer-range@1100.0.1':
+    resolution: {integrity: sha512-AHDx94T+1Advp9RR3Ew+DFnAv33YHlWcA/4i+9I/g34yYCv0OtqxpbMmTOT5Y96vCq8eCmW5R1DgLCV3NtVaoA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/engine.runtime.bun-resolver@1101.0.5':
+    resolution: {integrity: sha512-dGPxbPkaCsjQGxst5wVbubODe2Kd0S2PA4aHVAMscnaq4W2bRY5ccyzotQyMM0IcywCusJzll6EePHLxxN4SUg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/engine.runtime.deno-resolver@1101.0.5':
+    resolution: {integrity: sha512-JvpLOUHAdmHCThdJX4u3w8DoIE4chu5BpGR0T5FR4lpOjx2XwipTEasp2sglfMTzCtvciL0xDJdY/dDgUF6y4g==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/engine.runtime.node-resolver@1101.0.7':
+    resolution: {integrity: sha512-6tWQHRyDToeddQ53J8gu8pBQm+hAdL/TubwInQpTWaTmRc91bbhGWzMQjZ9tqKkbzSArpdfLGozA32FPlIkSpg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/engine.runtime.system-node-version@1100.0.3':
+    resolution: {integrity: sha512-GfzlG74JX2ACEF56H8GZG71tpT9ufx4FDdfnmTf+e9kHrH+YimeJAY6BuwPf1mL5TeIYqGAea9571OpivhEzVg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/error@1000.1.0':
+    resolution: {integrity: sha512-Dqc2IJJPjUatwc9Letw+vG29rnaMrDGi5g6WCx1HiZYm0obXbTmLygeRafMbgf+sLKXrWE1shOeiayQuczBdoA==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/error@1100.0.0':
+    resolution: {integrity: sha512-Pe+UcOhBwBBM38GPavnPJllik4/DZ8Fawt9+D2JLoWSo6FNZBJWQbaDMuwba3W0Ej0v43etKmyCT+MOvwt95Gg==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/error@6.0.1':
     resolution: {integrity: sha512-7yjO0RgmWYb4OKgcWC33yD4Z2CxE7Tm7vXX1SmS7GDifDT/bgZZhHeS2xq/+W6y9yhwIrRSA+7AlQL1NM2wIvw==}
     engines: {node: '>=18.12'}
@@ -447,9 +735,57 @@ packages:
     resolution: {integrity: sha512-OIYhG7HQh4zUFh2s8/6bp7glVRjNxms7bpzXVOLV7pyRa+rSYFmqJ8zDsBC64k58nuaxS85Ip+SCDjFxsFGeOg==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/exec.lifecycle@1100.0.9':
+    resolution: {integrity: sha512-xjRPiDoMj8wypvP23yWFmx18yDrIXwlbAERlGDDPvxjaFC8220Zw3DihToGP2m6Z/OAzxkx/V21UZqJ3NunILQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/exec.prepare-package@1100.0.9':
+    resolution: {integrity: sha512-qmqQMYzEgoXcvn+ew4DSzYXPda1fgO3zdYz+jmP0L6/m9lrC8y044S2u3hJURwM7rhlfn0um78l8bXvUylIBng==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/fetcher-base@16.0.1':
     resolution: {integrity: sha512-F4yFAqlmoVmzlxZTkEaYWQ454L0PVO4ZzTQgtEdBOOv10p9mEpTOz4z24+XSp6MHIIGH117oKeszXuTNoHA2eg==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/fetching.binary-fetcher@1101.0.5':
+    resolution: {integrity: sha512-wjDAvdw9ziDjWWS7o7VRvFookVGbIfVP+bc3tbjNQ04/nWRLbXZkdoPUe8Q/gnJpauwuBMvKJ7WGS5lP5vnbBw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/fetching.directory-fetcher@1100.0.8':
+    resolution: {integrity: sha512-pC1ONl1gyXZaDSh8IfafMxNS1vZ/6IFFmV/tbsB1eYkuDpsZW8B79gQeNio/qLtRdiocpp5ViZV83OtUauhxLQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/fetching.fetcher-base@1100.1.3':
+    resolution: {integrity: sha512-91W1zmxbLrKiAd3UM4x/gYeBwwMOdP7aFmykY3qPXE/VT1IyM05hDrhw7jdD8yZ/4wmq64u9meME3kB0/7kosw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/fetching.git-fetcher@1101.0.5':
+    resolution: {integrity: sha512-KmsDUAQtLop9pOBah62f60AsoOkb27sKs0FSAnwbtYMiPrgg18DZx9Z7p+nCo1z6BDfDMdDFKtnqJBDjsLqb4A==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/fetching.pick-fetcher@1100.0.6':
+    resolution: {integrity: sha512-n/nBTCx0IQpi97CbGLBmFoC0MO3+OlQ+Zo36sLfqcLcJ+POwTuwIU/ffMMtOH5iwFXYy+/GDAKADCY9+3D8xHw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/fetching.tarball-fetcher@1101.0.6':
+    resolution: {integrity: sha512-nxxP3jKRa2iz0ywgOTdsxTPePEe5d3oh7FvnhbZKUnhOl0CzB97v4vRgiqld9mjCe2E/gEqGG2j2rW9HRAcKGg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/fetching.types@1100.0.1':
+    resolution: {integrity: sha512-r/CIWju3OjQ4fPEogDLLmLvNbKyVmxqPNVmlq5Z7m98WVioowVzj/z4CWQKtykM9b+aEm+E7k2oR7XrLhoMl2w==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/find-workspace-dir@7.0.3':
     resolution: {integrity: sha512-eGjkyHSufkHyZ66WpygWnslcRePB0U1lJg1dF3rgWqTChpregYoDyNGDzK7l9Gk+CHVgGZZS5aWp7uKKVmAAEg==}
@@ -459,25 +795,206 @@ packages:
     resolution: {integrity: sha512-ee+ArUHSrmOIfX0/NAeItmIRApCGENny68yQFPJXatPcpj04cdtyGn92OEXVKAFgWoATZAPis+JLXX2NBlewHg==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/fs.graceful-fs@1100.1.0':
+    resolution: {integrity: sha512-sqz/s9GmCpMdTL1CP7lteu6EzV2FpAB2xBTztWh7ZCZUoM2MFQZlQI1OuCqdkn6VI3WRnhkUgV0pIOlbqFTCSw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/fs.hard-link-dir@1100.0.1':
+    resolution: {integrity: sha512-nAuAePsBm5l5NpsddrbwllykGltjzNeCihxjDTa7Hnjt+Lg0bozulKGG4ZbGcdvE/bz/1VBd4Z9i35p/WzWsyA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/fs.indexed-pkg-importer@1100.0.6':
+    resolution: {integrity: sha512-GG8icrYQFWMA46ZGc29I1Rp3eLsX4d5sf03sG90WP22p4vaSlKI067YB6rGL+DP+qBV0wlpAOIS28qUZr6Ulpg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/fs.packlist@1100.0.1':
+    resolution: {integrity: sha512-HmXaK8TiSFcHqtH3e77RPs2MgdpPE3JnIvj57hWHMZe6G3nnli+gYhs05t4+WHeQLGgRHcW6ppR/iQdr74XNWA==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/fs.packlist@2.0.0':
     resolution: {integrity: sha512-oy5ynSgI13FxkwDj/iTSWcdJsoih0Fxr2TZjUfgp1z1oyoust8+OxqCMOrHovJEKToHdPQgFtO09KbH7lAlN0w==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/fs.read-modules-dir@1100.0.1':
+    resolution: {integrity: sha512-VedTEgRfCyXsHSDIpF/V/RN/qiDOxnGgSA2cdPQRMc+gKXLdE2W906ZIZ5lTHWR7lDXvJZZB2l6fNUhXJ78ycA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/fs.symlink-dependency@1100.0.3':
+    resolution: {integrity: sha512-YGqszYj/oFHVCADs0u0tigczDsF3ph8jCeJ/hD2TEAkND7k3vFWV/ZL7VAG97JpH2qt17DuMqrkVB1xYTZmEhg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
   '@pnpm/git-utils@2.0.0':
     resolution: {integrity: sha512-k1rv4Zvno/5zJAqE/Mh9V0ehlm14NsYwpXTdaGMtyhkoHvlSckRfr23OIOIM7Q/TRX+LhqyJ2kep50SY2TsZ+g==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/global.commands@1100.0.16':
+    resolution: {integrity: sha512-fxmrDi7j1xXmKDPJ8Z6zEFv5UyJINz+Us/jSnN6Dc6khZWly2I8NS2ad8RHKrkX+xR9NRyuHJ7sUtY8P/nfjBA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/global.packages@1100.0.3':
+    resolution: {integrity: sha512-8qNhQP9PomhKI94cHn1v7qJq7utekw4U2cv7qxamHPTOZysEjygdvyVc104ZEj9vaxK2QYlMqBq92XgWevIDmA==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/graceful-fs@4.0.0':
     resolution: {integrity: sha512-933nhV2Prp51522poxX6Chvb7kEW3U3kzVWoqDU1+icB+QE7z/2qQ8wYHsBt4jm0Uil/sF67t77ugOr8bR63kg==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/hooks.pnpmfile@1100.0.7':
+    resolution: {integrity: sha512-guV8pQA9VJbgbAVtx7JMR0CyS7Ua/wbs82oaPSkStPKHxDuMGmaqVw3+PrqZN9VLlACTBXmTBLd7mLWZ2F/Z8A==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/hooks.read-package-hook@1100.0.3':
+    resolution: {integrity: sha512-W/XDbrmK4/TWuSz8kgBtmX920cPKIfsYm9c/RzaaPXmAwkknmAgahGI1Dd/2cYdikNz8R+OFJjvCgOosTcGInA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/hooks.types@1100.0.6':
+    resolution: {integrity: sha512-CA9HcnBT06gczl8c9kIrMahNI6g002mw2GePR6wpScrddiuS3BTQPB2pySPoJiq+6DEbYwxInGMEj+VH8KRL1g==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/hooks.types@2.0.2':
     resolution: {integrity: sha512-b+7ta7aAVUaSqufL09eC5n3pyWFo/Hwd/5cJaj7L4UkY2xJQSalNStE/4WQouaEmb5ARQuQJciE3XKjV1SKQbQ==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/hosted-git-info@1.0.0':
+    resolution: {integrity: sha512-QzmNiLShTnNyeTHr+cykG5hYjwph0+v49KHV36Dh8uA2rRMWw30qoZMARuxd00SYdoTwT8bIouqqmzi6TWfJHQ==}
+    engines: {node: '>=10'}
+
+  '@pnpm/installing.client@1100.0.14':
+    resolution: {integrity: sha512-4S5m9rMjm9pMkQbIpxhFg3Fn2rgaf5iisnel58mP2GmNI0NNn2eGVHN8BDN0JNeGce0swtamzK9cHZkFn99tbw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/installing.context@1100.0.9':
+    resolution: {integrity: sha512-ISQTu1OUP0SWL5T0umHV7wKdbxNnotbWmRAcGPM0tSvyPuax5MQTWkv3fwam00wVdEZa2f4Q9Dmm33LhNYmscw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/installing.deps-installer@1101.1.1':
+    resolution: {integrity: sha512-z6XvOasULFF0zrwpcvDX41pvUWU4Q5fo0Sgg2hCTbRAmbjJBOLmratlipdfdV7q9sXsZabHYCSAqDhgXhc9Ngg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/installing.deps-resolver@1100.0.9':
+    resolution: {integrity: sha512-SLMNJvcjTfvOBLc+zsxeK/KnwX4MBEPu7qrEK+ei5ujJnGYtKV5VUGbTzyIZVMUAAUsUb2QOornnUseYRJ0DTg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/installing.deps-restorer@1101.1.1':
+    resolution: {integrity: sha512-PzaTKnXtnzJ/N5er39/H41sH7GpcDjERdzF3T8Hm3kMjgMdTsPtembkVn9Vh6Ut70YYw3LekQna/cYISpZolFg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/installing.linking.direct-dep-linker@1100.0.3':
+    resolution: {integrity: sha512-N5ic5wyVIFNIMPY01XgpgY9wAbzOiUI4ZNwLpSgcPLgzZTIDzlumEY1a6UTslwoN+l8WcVbKZEo9RMUA46s35g==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/installing.linking.hoist@1100.0.5':
+    resolution: {integrity: sha512-cCS2Ky71zO454Ap3b1YxCRjD+i7n5a9kBpwFlHSUwDF0FplNBwjU561pao0cyu2zXd4mz+6daVjhdhYQ3Temyw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/installing.linking.modules-cleaner@1100.1.0':
+    resolution: {integrity: sha512-My86JWg1vP5uXJoVagNVVHKF1JYc8M4TTNwJNJf7bBzl54DsJKXAzFN1hM1XIcB1HqieWtdnr6wIJFrfynVdsw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/installing.linking.real-hoist@1100.0.7':
+    resolution: {integrity: sha512-qTHQZf7lPRrXXm5mF0TXKxmoHX7ydZDVP3dWTWfMcLWuMigOVcyJv0m5KZkVxsv9EFfjYN0IBPCPoWKdZ5J0sA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/installing.modules-yaml@1100.0.4':
+    resolution: {integrity: sha512-fbpckwAIG4VQ8ONMM0mqKNi59h5oHcUbdcYi5yCWIUCaLmACaoIvvUpVbORgSoI36agjeyHADbB9qmTwMvwWgg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/installing.package-requester@1101.0.5':
+    resolution: {integrity: sha512-lRgTn/3OnIRg9gWY7f2zozfFb/p+v42Pz6kSNj24EUMm4TcfyQzbxK1ouDdRN+fbTZibiDmWgRk68wi9iulTTg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/installing.read-projects-context@1100.0.8':
+    resolution: {integrity: sha512-h/Xr3QU4K6JMSIhFiCOx/NqSV8SooOZVYGxeW6m6vbtUXjdZH5hecT7zUw4CRQ4Pxknz/p+6HLElN02IJbx2vg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
   '@pnpm/lockfile-types@7.1.0':
     resolution: {integrity: sha512-QO+FlNjDiBt+u5esPhvq1d0uv89KCAmlLBkhj/6cQZa7Uq/a/jfRdNGJCthrrEnerwTKipPTNgyuctQE8vQK+Q==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/lockfile.detect-dep-types@1100.0.5':
+    resolution: {integrity: sha512-Cm1Nd4//Xdo7YhDibFIO9Ms3x0uZR2iUAZBy4TWO/C2u2murYoYiWURmjj0cndW5bCS7PJmg/9+UtC6odOrFGw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.filtering@1100.1.0':
+    resolution: {integrity: sha512-JkRXemw70vG0aW3rOgjDKFZmU8GGdXfLmqsqFIdOWGYTeQoaXpJDMvQzBgxojk2NiI8LOvy4jOcTLp/kgnbk0A==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/lockfile.fs@1100.0.7':
+    resolution: {integrity: sha512-p74Oiz286BGyVOs2u9KVY3HO01BntlnMtv8zUz4sIHVFO8yArFc5YAIVNa8hb1whL8z5RxF7b3GMkJ0A+QAyQg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/lockfile.merger@1100.0.5':
+    resolution: {integrity: sha512-RxYdS61WzK0SjSk7kwaEF1fWsBvAta5olXNbaIgRxrV6ZO5Au/GTIZ4+BA9Pe7q5RWFSpcSdX6W2gjEX9QS+9Q==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.preferred-versions@1100.0.8':
+    resolution: {integrity: sha512-1OR0JNIuCwxM8INqzsp30EW8wTq4YtuMPwE4V5QkJRphUcBqYGjWVdPZBahbbkf/qZhrkfrspi9B2uV0Y8HKvQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.pruner@1100.0.5':
+    resolution: {integrity: sha512-LUZReMx7X0oOFjqggG7COo8U/h6IgOQgNriDcN5GvcB3zRi9VIAbKk8ntYKlz8zQtMSW4IcEygxJ9ynrVzWKjw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.settings-checker@1100.0.9':
+    resolution: {integrity: sha512-1i6EQXrZyslSWeeJr5Uyr0RQnD9zST9cSiJAfyhCXJU/RqOw8mP9jHrOCv+US7dmvCly+XtZhl8ngDWV1tnHaw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.to-pnp@1100.0.7':
+    resolution: {integrity: sha512-jysa7dv+75BFhoVNTGbcT5SZMyVy6bSvgh0FKgGvZoYQUYsO5ExWKuOWQlEMcugZg492H79on/lXhc46i1b4+g==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/lockfile.types@1100.0.5':
+    resolution: {integrity: sha512-lAF9J34VKS7j+jWcM8h//EoNARmj/gG0YKFgqadTbj1+rCgep1N57xIo3kg4tbtlVLHXH9cM/yX7UxUtJt7mXQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.utils@1100.0.7':
+    resolution: {integrity: sha512-BWWmNaHjaAxcLpfHaHo4pS+EfvszwnOww92gs3mynTQdv/Wnn5nY+4Uljgovc5wpqtV6tb7pEn/3A/6gHUwDKQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.verification@1100.0.9':
+    resolution: {integrity: sha512-NslCBjbmWWRCa5t00zc/oFaV0f6ZD6uRsTnMwtkCXnr31IzwMkpVfV7+WLrAziI3jUo9NuzfEeTRtb9O1gycwg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/lockfile.walker@1100.0.5':
+    resolution: {integrity: sha512-+bQ1EJjIPewHAadSF+P7yFyoOURvXU7idPFr6zri2UXc76OoX7zK9oSC5Pswa9nT+BNa2/K60NuRgY+m9DWVAg==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/logger@5.2.0':
     resolution: {integrity: sha512-dCdSs2wPCweMkRLdISAKBOKSWeq/9iS9aanWgjoUkFs06KN2o5XGFg53oCXg/KbZhF9AXS3vMHPwTebzCeAEsA==}
@@ -491,9 +1008,23 @@ packages:
     resolution: {integrity: sha512-c2diPZzejRYnL6b00Ko70TnOlbsqydUOvAjOZ7THTs0ptXG/AARcwNp9YO5EXFq775TTmsSUBo99qisYF1ogNA==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/network.auth-header@1100.0.2':
+    resolution: {integrity: sha512-uWO9IZ1+lDSOaoAHALTm2USVDavBGHH9BRcHpoH1CsW1/UVcqdZzAMknNj0B4HuDwVR4qcyY89J3Fz6bGxwRuw==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/network.ca-file@1.0.2':
     resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
     engines: {node: '>=12.22.0'}
+
+  '@pnpm/network.fetch@1100.0.3':
+    resolution: {integrity: sha512-8lih2bNRIlCNUZW7zPnPGqUYO9vyH2DDGQ2XIp1T7vBiRfCtKZmtX8qAteguVz64m6+B5ZYqB0UavvFgdoiRzw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/network.git-utils@1100.0.1':
+    resolution: {integrity: sha512-JMy0iHEiTQB73oHlEVJhFz6OvHsqY9mYQjWFifEXkyPrRpGi/fpu0y+qfeBnNyR3j9kaXO4Imtlb5rV3c28GvQ==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/npm-conf@2.2.2':
     resolution: {integrity: sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==}
@@ -502,6 +1033,18 @@ packages:
   '@pnpm/npm-conf@2.3.1':
     resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
     engines: {node: '>=12'}
+
+  '@pnpm/npm-lifecycle@1100.0.0-1':
+    resolution: {integrity: sha512-sqXZFikFaJfwY8K+Gg9oPMxxYnJ9O7OkMxXAWNPBUEiZh8XK/DaNFlbNOJ3X8P0WKS5nDE9A6TiOBWrhTrpS+A==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/npm-package-arg@2.0.0':
+    resolution: {integrity: sha512-429x8dFMgxZoeYUTUPAMC09IeM5yQ86X1LyYEQF1P4uyvhLSCh44QKkiprX9qdwBsV9QxjeNad2QoDZy1RSeRw==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/object.key-sorting@1100.0.0':
+    resolution: {integrity: sha512-2p9Ew48onwdeuPctbHWSwet1j3JcA/ZHlCikfYyxwjBdvR1Rva/2YNgLKvMhzCOMTxQ+CyimisWkvCqaRrTicg==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/package-is-installable@9.0.2':
     resolution: {integrity: sha512-+OFh/J2OERTXpIIxbg9srvan8c7zv5zoVtdjNH2AZE+G9FdaNeJDZUGtncjJiu3K4SD/FJzpKb13wy3m1P3eww==}
@@ -516,6 +1059,37 @@ packages:
   '@pnpm/parse-wanted-dependency@6.0.0':
     resolution: {integrity: sha512-01hKf1qHKREZDOwa5wRXk01P+xBGOeZf/idg17si8ji7UWpdWEQkrUVmGfv3sT04XoiwIb7kaRiKPQT7ooB4fA==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/patch-package@0.0.1':
+    resolution: {integrity: sha512-AEgJoZH2goHdGWlyQ1cOMlgmjGLCqk88IFcbAolxWqlhawa3bSL1jLHnjwQc1XBwxeeUltL7mNmPR23q+VZTWQ==}
+    engines: {node: '>=14', npm: '>5'}
+    hasBin: true
+
+  '@pnpm/patching.apply-patch@1100.0.0':
+    resolution: {integrity: sha512-MKFov2lLFSAken/hCOsdOsAPpI922NDGz03hlxCiQlNwMHLD4czw7jUvYhwgKnRpv1LtMAPVvvQh2CZK9HFfFw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/patching.config@1100.0.3':
+    resolution: {integrity: sha512-9aYv4X5+8R4Wz/CeZb6b9PM6BOMVdIv3pBvkkC/xEeRoSxCL3VSBprp7gT4PHviXkhGKKk6z4/Iv+g7v6ybmgw==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/patching.types@1100.0.0':
+    resolution: {integrity: sha512-trrr0UIaIEIDagZhuxjO83z+/aCvyKib+g5zXQQ7d2H3bj8GN2sHPPi/5/i8C1eMiBGNZut/8cl8ipNRbFwIow==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/pkg-manifest.reader@1100.0.3':
+    resolution: {integrity: sha512-raOes34XZR98W7jriPS10a5HLY/y7+YM28nZSr8x5Im14iK0cmkzfgK9zOjv2945Lzvyw+wFNnBihQjcWDNh0Q==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/pkg-manifest.utils@1100.1.2':
+    resolution: {integrity: sha512-BMTqgAhb7ByA+MrV9Il2HVF0AaxSGwD1xnyTSUoieM9yaZR8T3nOxjucmvJzGN+o8JVrMs8nIjxYvm6SlG4sUg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
   '@pnpm/pnpmfile@6.0.4':
     resolution: {integrity: sha512-F15UJMpQVc2DFatLOEF9ne/eXkqooc8BGpfPfVkQsk4LnHMyZVfsxqU7U8jwmy3meaBw79XWDh2Oge7S3aTP6g==}
@@ -538,21 +1112,144 @@ packages:
     resolution: {integrity: sha512-EobGNigWvWSPNIZaA5GZFzq2ENutyVYmyTobz2vg6KPH2RLvVo3hO2VYTZ8ARPKOfsFLLFei90ncrm7k+Z5U1g==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/resolving.default-resolver@1100.1.1':
+    resolution: {integrity: sha512-tvLCeBdNGG0P8YmrKWizMywuFS3OqJqRv94u7yF+I/XKnGwzuAV8r7bmkum9QKgIlDJX9sfkjvO1lh72UM+wEg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/resolving.git-resolver@1100.0.6':
+    resolution: {integrity: sha512-mRpwtuXlOckUyIXPZdCsWCch2tGoXzogxZLwGae859qbNuB7UtEJTxVbBuE2lpQjfKYK2n3DqSvWFxzFXERCfg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/resolving.jsr-specifier-parser@1100.0.0':
+    resolution: {integrity: sha512-b/iTLwRvwoKNyIP0y5qdeRtBoswYGTppdH6tzXp8ORIZzeMkol30t4CwSTPZnIFVHWwN/PNhL7eQyhADus7KyQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/resolving.local-resolver@1101.0.0':
+    resolution: {integrity: sha512-vb7KTtQhNZ3OneNHHEt8L77NSRW4CMAPld35mlP0IpXnqhyOBxDI4sNatLbguneXhB2BX6KlY+v45OnKtyIm/g==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/resolving.npm-resolver@1101.1.0':
+    resolution: {integrity: sha512-hFbvZK/AP0fcmK6y/8SHqOwyFQC14TJT8LfjrPueRM2LQncMelRU9z2MzO3lsN+lKn9XBUUOCU5f3zZw3/OCJA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/resolving.parse-wanted-dependency@1100.0.1':
+    resolution: {integrity: sha512-GwWBQJb6vZRrLTZho6vdj9M0Bs+AIW8fYNnGdTy1yBcMyWo9UVDEDaFzeMWMa5mC1pVglyQIU3kJ4gDMhp/OYw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/resolving.registry.pkg-metadata-filter@1100.0.3':
+    resolution: {integrity: sha512-hpjqApF0mUHqlB/KuL7qWDlsVMa6yZiPdEoiThW1yKJ/ar2rMQfTtUURYIGV1moloBhPZQQAlEkJJNSE2kKwAg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/resolving.registry.types@1100.0.3':
+    resolution: {integrity: sha512-YzWyZgJ6VriZzg+/EkDngJ+WOZTgRGnet/UXPzBfFZ15DfgeLt7swiSX1Clyd/FrWJoZ2O5bv46WudGZaGfntA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/resolving.resolver-base@1100.1.3':
+    resolution: {integrity: sha512-Phy0I8TnUbILfxwjFn6lTvud0zWUS8yWZooOPh8OFnuclcl0E3QmpvpirANJX6Xt5PhrxPydQ5xlLFnOY9gWlw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/resolving.tarball-resolver@1100.0.5':
+    resolution: {integrity: sha512-dck5GeIw1dy2T75eN2xIOUzYQNg9uDIetbjbJ500x8whBPsnWImVcoEo2TYgiEHf+5hkhNaH4FokOpOgJtBTeQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/semver-diff@2.0.0':
+    resolution: {integrity: sha512-BeJTTAegvEHqgldGtJuZMCC0IfC/mVyxR1parznqCTtPwQSYrjft4tDvKd+oBMJQjcl7sp70G8rPR89ecpeicg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/slice-ansi@1.1.3':
+    resolution: {integrity: sha512-xrWctjDAHXzIths7OmtW8dZUFR8aX/9zdwi4QRhCU7XFJJHl2JJqZoh2zD2wSMjWW7z2CiXeWWvfqftniM3dTg==}
+
   '@pnpm/store-controller-types@18.1.0':
     resolution: {integrity: sha512-3FvgGtnWlKlC8CztqMqT5w2VTdOjKCu1ZrH+d5xFuVHyb2weIz9hxQo/3VHT+qdcN8O7q+rpzRgh3YtgO+r+tA==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/store.cafs-types@1100.0.1':
+    resolution: {integrity: sha512-UeXt5uecNdvQl9fdhgpiFvcBm18CDDKFzWj686uiPyQ7cGvu77RpEGk2cd7CfXvvaY89AaMfmdER0O1+8UA51A==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/store.cafs@1100.1.3':
+    resolution: {integrity: sha512-nLdewM1yAO9HUCkh9gQM/ZLe1vM3dKDNDLL/tFT+Ez+MxI59AeedJB56H+vYJDKUn960ZpF/IrPYE0AupM5dPA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/store.connection-manager@1100.1.1':
+    resolution: {integrity: sha512-NHJMOg7+/+ikgKh56W4mSo5wHL1MHH6eDA2xFrcOTvgA9fJdhK6Z3bQVQMdDA5xOn0hw2b1kS5BVAC/OhFPcbA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/store.controller-types@1100.0.6':
+    resolution: {integrity: sha512-GxbTRKbQcDN6Anw0MHr1Pj6GYA1siHj30LD5/+tNtwJzrf1bUgbJi8GNVA0RkYLkqp6jQRCu/zHbpNrfg/EIvw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/store.controller@1101.0.5':
+    resolution: {integrity: sha512-iNoCGQ4ReKrBSZ3WcLHwTg7MYBkYc6aBm98kxN+tNtpNZFcLRzJND77xN/k+0RaJ2628Sgmf8dp2Za465lhuXQ==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+      '@pnpm/worker': ^1100.1.4
+
+  '@pnpm/store.create-cafs-store@1100.0.6':
+    resolution: {integrity: sha512-vE4RKqo2CC1Ecm4umb35d3soF4izy3xoL4VHp9thacroez72HQR3Hf0lYmKXUOWC7y7b2qlkhck0LHBWsAqQow==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/store.index@1100.1.0':
+    resolution: {integrity: sha512-UIDG/VwaKz3rViR1FCSzr3CJpJgERKC/zBMBGdAVoFPitDpaTJZpCousDQQQ9QoIwyEZmbh6eYxIAS4ZMo3yfg==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/store.path@1100.0.1':
+    resolution: {integrity: sha512-gqzKBgzasRFp4dsVs0mozDAuedcgBpFS7sc8xYhyuGFvcS52kv6PAl8kCEtafHe+f9qhH0/xsEF4C5Ux/N4H2Q==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/tabtab@0.5.4':
+    resolution: {integrity: sha512-bWLDlHsBlgKY/05wDN/V3ETcn5G2SV/SiA2ZmNvKGGlmVX4G5li7GRDhHcgYvHJHyJ8TUStqg2xtHmCs0UbAbg==}
+    engines: {node: '>=18'}
+
+  '@pnpm/text.comments-parser@1100.0.0':
+    resolution: {integrity: sha512-POntpaKUaDXaRBYLKZTnd0uxYZSMGLwpS3BqENlH4SEyz/8OK409573XtJgOQgtpmLM3DHZ6iJaRcr8ig6qSnw==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/text.comments-parser@3.0.0':
     resolution: {integrity: sha512-BSGvYd59kPKVTUk1InekEp+TiPnJ8650/bQyiOUFSvqHi61YipcR+E4H2i3xTnk2e+GHdGbXvEtAZbQmyxb0/g==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/text.naming-cases@1100.0.1':
+    resolution: {integrity: sha512-E1QI3mkvGNIHm3lHbNxmkKWNhu9lgfq15Jf+0Hz8BelHjMWACR4MGW4NU8Jw2/miE7BnGqyQd7JHansYzt+12g==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/text.tree-renderer@1100.0.0':
+    resolution: {integrity: sha512-xX/sm35sA8QP/PH13w67xdwTm29H3GG80Fgx+pWVkvyXSpaMAGCN/2s4GauT+TilnbJuCx255x+gTVrZFz6N1w==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/types@10.1.0':
     resolution: {integrity: sha512-cM2UhtQJs06zWm3wsXoVVi4b1P8rA7xioZCct/Q4sR5GAUq0VUReZMd9TkPEVdNlAiitctTAi9EM8D5hrO937A==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/types@1101.1.0':
+    resolution: {integrity: sha512-GHsA28MMPIloKhcLC+EFBH8rUtfcailUsp6ms1jeYZsEXLsbgi8cnpftxohFx+A0W3i7+eQdMX6RXvdctZ7qWQ==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/util.lex-comparator@3.0.0':
     resolution: {integrity: sha512-ead+l3IiuVXwKDf/QJPX6G93cwhXki3yOVEA/VdAO7AhZ5vUuSBxHe6gQKEbB0QacJ4H5VsYxeM1xUgwjjOO/Q==}
     engines: {node: '>=18.12'}
+
+  '@pnpm/util.lex-comparator@3.0.2':
+    resolution: {integrity: sha512-blFO4Ws97tWv/SNE6N39ZdGmZBrocXnBOfVp0ln4kELmns4pGPZizqyRtR8EjfOLMLstbmNCTReBoDvLz1isVg==}
+    engines: {node: '>=18.12'}
+
+  '@pnpm/worker@1100.1.4':
+    resolution: {integrity: sha512-bgtWHFSoIDFCd4uuWS6cRfF1DkQg31lUXiYcEagl7iR9EYSQAQbiFwMqJZRkxah+QkO7uSORQaAz5+l78sONXA==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
   '@pnpm/workspace.find-packages@2.1.1':
     resolution: {integrity: sha512-BRSaRgBNLxEiunTwEXGGglRRwF84Ci6ZI6AUy9j4aviSpDSZ2wtYCCGA0+KM36GLbrg2exyhiG/ls/eI6QHJKQ==}
@@ -560,13 +1257,87 @@ packages:
     peerDependencies:
       '@pnpm/logger': ^5.0.0
 
+  '@pnpm/workspace.project-manifest-reader@1100.0.4':
+    resolution: {integrity: sha512-51RRGNJK8P6hClKp8qNBCEKS+G6blRHht6f0IT2UtDnDPLBwF7L96lYa/Y/UlCnaW5MiUdwvHrCLoBDTpoxhow==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': '>=1001.0.0 <1002.0.0'
+
+  '@pnpm/workspace.project-manifest-writer@1100.0.3':
+    resolution: {integrity: sha512-uyQI1kKigRax6qQeepYNVWtafTzz/6Q8FElef1rCb0QcFa1+ear5IKIox5Rb+g86Ox3TX3B6sOXw3gbxLLnvUw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/workspace.range-resolver@1100.0.1':
+    resolution: {integrity: sha512-RaI/BUL76Q7PeRgx1lKWIA93EdbyAYJK2BF6go3YYslJrIHSu6j3eaWUWxSDYphizlPRcUbp0QH2q+oh2cX7zA==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/workspace.read-manifest@2.0.1':
     resolution: {integrity: sha512-Aqk77F3CFuN/qNeAIIm8MtwowRZvf5Ei9uq7cySLx44Q23XocGddE7r/5LnmVpD0t4e5Qu5j+mbcRqCJcjhMsQ==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/workspace.spec-parser@1100.0.0':
+    resolution: {integrity: sha512-tjTU6mSIx38pxOlzzKkQXjEgYr68jZv2b4+uORFPq5rVPz95iSCooSfxMsXQcbxmqQ6yiMnZcCfOQFz88rNHNw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/workspace.workspace-manifest-reader@1100.0.3':
+    resolution: {integrity: sha512-CgOqx4sCKpNkAKLa0sqpez8Ql73uBkJzr8X7bXaLJ7KLYtJeLaKehjxWAliK1DXYtyl1GcZWMuj5IlFd64bzxw==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/write-project-manifest@6.0.1':
     resolution: {integrity: sha512-K94P822XIdQ2YhyHbBL/jzasVo2YKGOnfbMzJIM3xFBFeVpv+hPxM4Xkac4IskRFSJQoTQgjZy8KbXKXnXxfyw==}
     engines: {node: '>=18.12'}
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
 
   '@rollup/rollup-android-arm-eabi@4.41.0':
     resolution: {integrity: sha512-KxN+zCjOYHGwCl4UCtSfZ6jrq/qi88JDUtiEFk8LELEHq2Egfc/FgW+jItZiOLRuQfb/3xJSgFuNPC9jzggX+A==}
@@ -668,19 +1439,50 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rushstack/worker-pool@0.7.7':
+    resolution: {integrity: sha512-B8uRKeYvtUQkdno1TTvp86DWcV98JOy/qf0KPr9hKfzi/l4B0hM2ES/tR+ae9dX5z1vX9AEy60n7yyrsQh3YUA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
+
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
 
+  '@types/bintrees@1.0.6':
+    resolution: {integrity: sha512-pZWT4Bz+tWwxlDspSjdoIza4PE5lbGI4Xvs3FZV/2v5m5SDA8LwNpU8AXxlndmARO7OaQ1Vf3zFenOsNMzaRkQ==}
+
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
+
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
@@ -688,8 +1490,14 @@ packages:
   '@types/glob@8.1.0':
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
 
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
@@ -697,14 +1505,29 @@ packages:
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.15.21':
     resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/rimraf@3.0.2':
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
 
+  '@types/semver@6.2.7':
+    resolution: {integrity: sha512-blctEWbzUFzQx799RZjzzIdBJOXmE37YYEyDtKkx5Dg+V7o/zyyAxLPiI98A2jdTtDgxZleMdfV+7p8WbRJ1OQ==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
   '@types/ssri@7.1.5':
     resolution: {integrity: sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==}
+
+  '@types/treeify@1.0.3':
+    resolution: {integrity: sha512-hx0o7zWEUU4R2Amn+pjCBQQt23Khy/Dk56gQU5xi5jtPL1h83ACJCeFaB2M/+WO1AntvWrSoVnnCAfI1AQH4Cg==}
 
   '@vitest/expect@3.1.4':
     resolution: {integrity: sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==}
@@ -735,24 +1558,105 @@ packages:
   '@vitest/utils@3.1.4':
     resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
 
+  '@yarnpkg/core@4.5.0':
+    resolution: {integrity: sha512-jZnEYfP05k3KpBIWlNkPEuJ3E0QLnYTNALQOH+7x8LAQyzhnN9yuLZx8Ze80Y7mlU1Hnv5wUGtzzUFn1wyBAlQ==}
+    engines: {node: '>=18.12.0'}
+
+  '@yarnpkg/core@4.7.0':
+    resolution: {integrity: sha512-/zOgPAcDvwx8NDzLidDFaZDg+3Jgv824C4fudqZFlUuWv/BzOEtjfRTAyi+O0h15FyT7YvlsMnQpmnIQB+LgKw==}
+    engines: {node: '>=18.12.0'}
+
+  '@yarnpkg/extensions@2.0.6':
+    resolution: {integrity: sha512-3LciOqpKIuoc9MmYoX3k+NmCdcrvw7HqZT4N/AW3sYkujxfbFA9Ml01JNqu4InzdV9V9NcyFkAKAorCjhY8w6Q==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@yarnpkg/core': ^4.4.2
+
+  '@yarnpkg/fslib@3.1.5':
+    resolution: {integrity: sha512-hXaPIWl5GZA+rXcx+yaKWUuePJruZuD+3A5A2X6paEBfFsyCD7oEp88lSMj1ym1ehBWUmhNH/YGOp+SrbmSBPg==}
+    engines: {node: '>=18.12.0'}
+
+  '@yarnpkg/libzip@3.2.2':
+    resolution: {integrity: sha512-Kqxgjfy6SwwC4tTGQYToIWtUhIORTpkowqgd9kkMiBixor0eourHZZAggt/7N4WQKt9iCyPSkO3Xvr44vXUBAw==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      '@yarnpkg/fslib': ^3.1.3
+
+  '@yarnpkg/lockfile@1.1.0':
+    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
+
+  '@yarnpkg/nm@4.0.7':
+    resolution: {integrity: sha512-cY2dzqRoNIOwKtmVVdJojnzjYdQ6klYefa9Urv61cKY5bdrU/5NZdzQoa3/i9Ls7L9qYCg/9V2WGmEG2rCu64w==}
+    engines: {node: '>=18.12.0'}
+
+  '@yarnpkg/parsers@3.0.3':
+    resolution: {integrity: sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==}
+    engines: {node: '>=18.12.0'}
+
+  '@yarnpkg/pnp@4.1.5':
+    resolution: {integrity: sha512-hDqB3Kke873wdx3rip1zlblfBIx2sGJH0BoNPh435A5rSEVT1sDKuCykLxNlLUnGhIZc83FXLGDGZJn23ggAQg==}
+    engines: {node: '>=18.12.0'}
+
+  '@yarnpkg/shell@4.0.0':
+    resolution: {integrity: sha512-Yk2gyiQvsoee/jXP9q0jMl412Nx27LYu+P1O4DHuxeutL9qtd6t3Ktuv+zZmOzFc6gMQ7+/6mQFPo3/LlXZM3w==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
+  '@yarnpkg/shell@4.1.3':
+    resolution: {integrity: sha512-5igwsHbPtSAlLdmMdKqU3atXjwhtLFQXsYAG0sn1XcPb3yF8WxxtWxN6fycBoUvFyIHFz1G0KeRefnAy8n6gdw==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
+  '@zkochan/cmd-shim@9.0.3':
+    resolution: {integrity: sha512-u2kKE7N/UapZ0RyAQTNcnSQ9SYbvtcgwzfXl3WHcoJvja69T15Dou//ZU6Bsk3p0M6fFWD5ip+uwkJy61TvaMA==}
+    engines: {node: '>=22.13'}
+
+  '@zkochan/js-yaml@0.0.11':
+    resolution: {integrity: sha512-SO+h5Jg079r2JvGle0jbdtk1EY7ppu6TGzmfWTp3Gy61IEb1OVKBocJ6ydTn4++nYFNfRKYenI2MniZQwsM9KQ==}
+    hasBin: true
+
+  '@zkochan/retry@0.2.0':
+    resolution: {integrity: sha512-WhB+2B/ZPlW2Xy/kMJBrMbqecWXcbDDgn0K0wKBAgO2OlBTz1iLJrRWduo+DGGn0Akvz1Lu4Xvls7dJojximWw==}
+    engines: {node: '>=10'}
+
+  '@zkochan/rimraf@4.0.0':
+    resolution: {integrity: sha512-0EdBn93hMsbx4svJsKQCch+sNMuXvzWbVYqTCGdctQmxtuYK57uCURZPNiNdwS2Y31d96DMWI3BpJ9DLN2Jxfw==}
+    engines: {node: '>=22.13'}
+
+  '@zkochan/table@2.0.1':
+    resolution: {integrity: sha512-o+nA2fbYPcngLhCTuBQYkdt0Ef6lb8ppaGpXtz/9qsm1F9g5e9UQe8LGkT6NnkcGtwU/hlMvckuGafRGHP3NxQ==}
+    engines: {node: '>=16.14'}
+
   '@zkochan/which@2.0.3':
     resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.14.1:
-    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
@@ -762,11 +1666,18 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
 
   ansi-diff@1.2.0:
     resolution: {integrity: sha512-BIXwHKpjzghBjcwEV10Y4b17tjHfK4nhEqK3LqyQ3JgcMcjmi3DIevozNgrOpfvBMmrq9dfvrPJSu5/5vNUBQg==}
@@ -800,6 +1711,9 @@ packages:
   archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -828,6 +1742,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
@@ -835,9 +1753,20 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-path-resolve@2.0.0:
+    resolution: {integrity: sha512-VvvsZgI0upmMbG1iEFiQ7hRG+fDJwmw7iFfKLzBVNhRd2ycauJ3+3w50ESX+pS2tvS9R2hMzijwE+vinDyqQzQ==}
+    engines: {node: '>=22.13'}
+
   bin-links@3.0.3:
     resolution: {integrity: sha512-zKdnMPWEdh4F5INR07/eBrodC7QrF5JKvqskjz/ZZRXg5YSAZIbn8zGhbhUrElzHBZ2fvEQdOU59RHcTG3GiwA==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  bin-links@6.0.0:
+    resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bole@5.0.19:
     resolution: {integrity: sha512-OgMuI8erST2t4K/Y+tSsn4SOxlKj4JR2wluQgLYadQFPIhj0r3jcmnp0OthgiyNO91CnxR8woKeLQmnMPgl1Ug==}
@@ -851,6 +1780,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -867,9 +1800,21 @@ packages:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
     engines: {node: '>= 10'}
 
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
+  cacache@19.0.1:
+    resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
+    engines: {node: '>=8'}
+
+  camelcase-keys@10.0.2:
+    resolution: {integrity: sha512-PVHCLVbJ7nWGal0lPAmBN5eSLjIynlMUk2EPmL9aPl6QyJ6+FoszTKwldPzkuVqg5teZbPTbb8Oenzyw9GSJRw==}
+    engines: {node: '>=20'}
 
   camelcase-keys@6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
@@ -883,20 +1828,36 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
+  camelcase@9.0.0:
+    resolution: {integrity: sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==}
+    engines: {node: '>=20'}
+
+  can-link@3.0.0:
+    resolution: {integrity: sha512-dhguuV14nOt9Jdg1crCPqeY+k9pzE2SatedDbKGYei+0wQA9gw/uh4PsFmpTbaLVqvInZtrO3Uj60Bu6Ek/UUQ==}
+    engines: {node: '>=22.13'}
+
   can-write-to-dir@1.1.1:
     resolution: {integrity: sha512-eOgiEWqjppB+3DN/5E82EQ8dTINus8d9GXMCbEsUnp2hcUIcXmBvzWmD3tXMk3CuBK0v+ddK9qw0EAF+JVRMjQ==}
     engines: {node: '>=10.13'}
+
+  can-write-to-dir@2.0.0:
+    resolution: {integrity: sha512-4wXLh+SqvKDzWND9SGE8cWllVMc65LxHVrCePc56IbfrtORUyxTWCVMI8rbGIVRBSNf5C+zbfaken7Abs34AEQ==}
+    engines: {node: '>=22.13'}
 
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chalk@5.4.1:
-    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
@@ -910,6 +1871,18 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -932,6 +1905,11 @@ packages:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
 
+  clipanion@4.0.0-rc.4:
+    resolution: {integrity: sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==}
+    peerDependencies:
+      typanion: '*'
+
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
@@ -939,13 +1917,28 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  cmd-extension@1.0.2:
+    resolution: {integrity: sha512-iWDjmP8kvsMdBmLTHxFaqXikO8EdFRDfim7k6vUHglY/2xJ5jLrPsnQGijdfp4U+sr/BeecG0wKm02dSIAeQ1g==}
+    engines: {node: '>=10'}
+
+  cmd-extension@2.0.0:
+    resolution: {integrity: sha512-KmDsvn5CnKlELO9vQ7nTfn5aK4H1QSvUfm3h5natue7pjhwsOPyGMpzEL0d5XUZ0YzTiBODcaayRNsXCF9n3Fw==}
+    engines: {node: '>=22.13'}
+
   cmd-shim@5.0.0:
     resolution: {integrity: sha512-qkCtZ59BidfEwHltnJwkyVZn+XQojdAySM1D1gSeh11Z4pW1Kpolkyo53L5noc0nrxmIvyFwTmJRo4xs7FFLPw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  cmd-shim@8.0.0:
+    resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -958,6 +1951,10 @@ packages:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
     engines: {node: '>=20'}
 
+  comver-to-semver@2.0.0:
+    resolution: {integrity: sha512-4pxiLt2bXHe5BDrolTJs9wfwwT0pPQPQxeUj+X6SKTCkpi8VwvOvgMzohTVVDLXHmAjrZuKEq+tyb0C5zzTSxw==}
+    engines: {node: '>=22.13'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -969,6 +1966,10 @@ packages:
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
+  cross-spawn@7.0.3:
+    resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
+    engines: {node: '>= 8'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -976,6 +1977,10 @@ packages:
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
+
+  crypto-random-string@4.0.0:
+    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
+    engines: {node: '>=12'}
 
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
@@ -988,6 +1993,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -1007,9 +2016,29 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
+
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
+
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
+
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
+
+  dir-is-case-sensitive@3.0.0:
+    resolution: {integrity: sha512-xId1VV2XkiiETrOZPb8zcXHGbM7UEwIbHX0Cd6Dtxc1pIsWT7Yphvft/r/cI6Zz45zaj/LeUYU8h5IraHvm7SQ==}
+    engines: {node: '>=22.13'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1023,11 +2052,26 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encode-registry@3.0.1:
+    resolution: {integrity: sha512-6qOwkl1g0fv0DN3Y3ggr2EaZXN71aoAqPp3p/pVaWSBSIo+YjLOWN61Fva43oVyQNPf7kgm8lkudzlzojwE2jw==}
+    engines: {node: '>=10'}
+
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+
   ensure-posix-path@1.1.1:
     resolution: {integrity: sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -1037,6 +2081,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
   esbuild@0.25.4:
     resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
@@ -1051,21 +2098,25 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-scope@8.3.0:
-    resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  eslint-visitor-keys@4.2.0:
-    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@9.27.0:
-    resolution: {integrity: sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  eslint@10.3.0:
+    resolution: {integrity: sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -1073,12 +2124,17 @@ packages:
       jiti:
         optional: true
 
-  espree@10.3.0:
-    resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  esquery@1.6.0:
-    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -1096,17 +2152,23 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  execa@9.5.3:
-    resolution: {integrity: sha512-QFNnTvU3UjgWFy8Ef9iDHvIdcgZ344ebkwYx4/KLbR+CKQA4xBaHzv+iRpp86QfMHP8faFQLh8iOc57215y4Rg==}
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
+
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
@@ -1127,11 +2189,19 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-string-compare@3.0.0:
+    resolution: {integrity: sha512-PY66/8HelapGo5nqMN17ZTKqJj1nppuS1OoC9Y0aI2jsUDlZDEYhMODTpb68wVCq+xMbaEbPGXRd7qutHzkRXA==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
-  fdir@6.4.4:
-    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1150,9 +2220,19 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
+    engines: {node: '>=18'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  find-yarn-workspace-root2@1.2.53:
+    resolution: {integrity: sha512-0P66/qSVapUMgxLt0BwnKQ2VEg7uR/PIX82y/YuKOf8oHK437uq3OcMUdB4NGDJrCZ2is6jME0yZcV9nAM0RoQ==}
+
+  find-yarn-workspace-root@2.0.0:
+    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
 
   fixturify-project@7.1.3:
     resolution: {integrity: sha512-araEoNawWCIV9xT/+kAQ+H3aiFTVVH1nUDuYU7syhbWnlyA6BzuRE7vhdZQ7m+1+T5A3zG2JljGxRkNP1EhvXQ==}
@@ -1177,8 +2257,12 @@ packages:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
 
-  fs-extra@11.3.0:
-    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+  fs-extra@11.3.4:
+    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   fs-extra@9.1.0:
@@ -1188,6 +2272,10 @@ packages:
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
+
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -1201,8 +2289,16 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-npm-tarball-url@2.1.0:
+    resolution: {integrity: sha512-ro+DiMu5DXgRBabqXupW38h7WPZ9+Ad8UjwhvsmmN8w1sU7ab0nzAXvVZ4kqYg57OrqomRtJvepX5/xvFKNtjA==}
+    engines: {node: '>=12.17'}
+
   get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -1232,26 +2328,37 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
-
-  globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@16.1.0:
     resolution: {integrity: sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==}
     engines: {node: '>=18'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
 
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graceful-git@5.0.0:
+    resolution: {integrity: sha512-cmogaKKsYEW06+FriOqkhewEGf9YdMfpK/iSqtW02/GcXhSlsjNrSq1VqrM2zbMfWw0Og+lh5knLd730THxv/A==}
+    engines: {node: '>=22.13'}
+
+  graph-cycles@3.0.0:
+    resolution: {integrity: sha512-9qxd8BQK0tZJ3cRUW0Yn2q6P/9h+bgz/4UYuscpdxPz6851NNBA1IwoYDRHDpKzCqmr1UHlGHcp5+0WzpY9F7A==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
+  grapheme-splitter@1.0.4:
+    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1268,6 +2375,14 @@ packages:
     resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -1275,9 +2390,21 @@ packages:
     resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
     engines: {node: '>= 6'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -1298,13 +2425,13 @@ packages:
     resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  ignore-walk@8.0.0:
+    resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
-
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1313,6 +2440,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
 
   individual@3.0.0:
     resolution: {integrity: sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g==}
@@ -1338,12 +2469,21 @@ packages:
     resolution: {integrity: sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
     engines: {node: '>= 12'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1356,6 +2496,14 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-gzip@2.0.0:
+    resolution: {integrity: sha512-jtO4Njg6q58zDo/Pu4027beSZ0VdsZlt8/5Moco6yAg+DIxb5BK/xUYqYG2+MD4+piKldXJNHxRkhEYI2fvrxA==}
+    engines: {node: '>=4'}
+
+  is-inner-link@5.0.0:
+    resolution: {integrity: sha512-aSlGGPZ+pe6q3DRU8GGdUeG1rZckcHnkBEtCdhWYkPKY44BuQYnHr1sFqcOZFAIV1E1socv8/rMvQ5vHBvAMeg==}
+    engines: {node: '>=22.13'}
 
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
@@ -1376,6 +2524,10 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -1384,6 +2536,10 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
+  is-subdir@2.0.0:
+    resolution: {integrity: sha512-iOXmZKniv4jGFMSYc1K3V/XNl30X1d/m86BKTiDeE2MDULREgBiNpLXsqQKjyETOkWbOyXNQD4M4AZCH51pm7g==}
+    engines: {node: '>=22.13'}
+
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -1391,6 +2547,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1412,8 +2572,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   jsbn@1.1.0:
@@ -1432,6 +2596,9 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -1448,6 +2615,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  klaw-sync@6.0.0:
+    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
 
   ky@1.8.1:
     resolution: {integrity: sha512-7Bp3TpsE+L+TARSnnDpk3xg8Idi8RwSLdj6CMbNWoOARIrGrbuLGusV0dYwbZOm4bB3jHNxSw8Wk/ByDqJEnDw==}
@@ -1468,6 +2638,14 @@ packages:
     resolution: {integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==}
     engines: {node: '>=8'}
 
+  load-json-file@7.0.1:
+    resolution: {integrity: sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  load-yaml-file@1.0.0:
+    resolution: {integrity: sha512-Xw+A/X4c5R6GWu7ZUQgw1rnbfUr1P/hAZbDTrreo+/fP/YSGgxAKoWe2IcT+bt4RHuyIca6S7SMGcWx+QI3WIw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1475,8 +2653,14 @@ packages:
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
-  lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
+  lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -1484,8 +2668,16 @@ packages:
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
 
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -1493,6 +2685,14 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  make-empty-dir@4.0.0:
+    resolution: {integrity: sha512-YKBz1FUAkNBFkQCBdGvLgeq1d4grJOhcKLra9wkOklqdrn7JJwB3d7r9gZlQC/1EXAQQ4YkFO/EfnhvHXh3LpQ==}
+    engines: {node: '>=22.13'}
+
+  make-fetch-happen@14.0.3:
+    resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   make-fetch-happen@9.1.0:
     resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
@@ -1506,6 +2706,10 @@ packages:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
 
+  map-obj@6.0.0:
+    resolution: {integrity: sha512-PwDvwt/tK70+luLw5k9ySLtzLAzwf7tZTY9GBj63Y010nHRPjwHcQTpTd5JwQqITC2ty7prtxBo71iwyYY0TAg==}
+    engines: {node: '>=20'}
+
   matcher-collection@2.0.1:
     resolution: {integrity: sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1513,6 +2717,10 @@ packages:
   mem@8.1.1:
     resolution: {integrity: sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==}
     engines: {node: '>=10'}
+
+  memoize@10.2.0:
+    resolution: {integrity: sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -1533,6 +2741,22 @@ packages:
     resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
     engines: {node: '>=8'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1551,9 +2775,17 @@ packages:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
     engines: {node: '>= 8'}
 
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minipass-fetch@1.4.1:
     resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
     engines: {node: '>=8'}
+
+  minipass-fetch@4.0.1:
+    resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   minipass-flush@1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
@@ -1583,6 +2815,10 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mkdirp-infer-owner@2.0.0:
     resolution: {integrity: sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==}
     engines: {node: '>=10'}
@@ -1594,6 +2830,13 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.8:
+    resolution: {integrity: sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -1615,12 +2858,45 @@ packages:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  next-path@1.0.0:
+    resolution: {integrity: sha512-oWgXcUL3zi7KsPNoWLM2Z/EVaOMsZO8em4iAzJmqoo08zinMwsMvkrNbeLDztMdaPJryfYJvbx2OBoBYnPQKpg==}
+    engines: {node: '>=6'}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
+  node-gyp@11.5.0:
+    resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  normalize-package-data@8.0.0:
+    resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
   normalize-registry-url@2.0.0:
     resolution: {integrity: sha512-3e9FwDyRAhbxXw4slm4Tjv40u78yPwMc/WZkACpqNQOs5sM7wic853AeTLkMFEVhivZkclGYlse8iYsklz0Yvg==}
+
+  normalize-registry-url@2.0.1:
+    resolution: {integrity: sha512-Ad5kiOvJFA62l6bkzuekf3AbEyCPweePeGIfU9iHtqem68EVKu2Tr6YM+xmO1dkwTzKgTCqzb3NqfIEtWWbQBg==}
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
 
   npm-bundled@2.0.1:
     resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
@@ -1638,9 +2914,17 @@ packages:
     resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  npm-normalize-package-bin@5.0.0:
+    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   npm-package-arg@12.0.2:
     resolution: {integrity: sha512-f1NpFjNI9O4VbKMOlA5QoBq/vSQPORHcTZ2feJpFkTHJ9eQkdlmZEKSjcAhxTGInC7RlEyScT9ui67NaOsjFWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-packlist@10.0.4:
+    resolution: {integrity: sha512-uMW73iajD8hiH4ZBxEV3HC+eTnppIqwakjOYuvgddnalIw2lJguKviK1pcUJDlIWm1wSJkchpDZDSVVsZEYRng==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   npm-packlist@5.1.3:
     resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==}
@@ -1663,12 +2947,20 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1678,21 +2970,49 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
+
   p-defer@1.0.0:
     resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
     engines: {node: '>=4'}
+
+  p-defer@4.0.1:
+    resolution: {integrity: sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==}
+    engines: {node: '>=12'}
+
+  p-every@2.0.0:
+    resolution: {integrity: sha512-MCz9DqD5opPC48Zsd+BHm56O/HfhYIQQtupfDzhXoVgQdg/Ux4F8/JcdRuQ+arq7zD5fB6zP3axbH3d9Nr8dlw==}
+    engines: {node: '>=8'}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
 
+  p-filter@4.1.0:
+    resolution: {integrity: sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==}
+    engines: {node: '>=18'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@7.3.0:
+    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
+    engines: {node: '>=20'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-map-values@0.1.0:
+    resolution: {integrity: sha512-IMr3wlbvIFnAIkUiJEZ4gUtMMte1tzDm+mehuFXJT7nXgluGsv6HbHaxuVgTc2D/LmKWOjdZN5IxnjVuudlt1w==}
+    engines: {node: '>=22.13'}
 
   p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -1706,16 +3026,36 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
+  p-map@7.0.4:
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+    engines: {node: '>=18'}
+
+  p-memoize@8.0.0:
+    resolution: {integrity: sha512-jdZ10MCxavHoIHwJ5oweOtYy6ElPixEHaMkz0AuaEMovR1MRpVvYFzIEHRxgMEpXYzNpRVByFAniAzwmd1/uug==}
+    engines: {node: '>=20'}
+
+  p-queue@9.2.0:
+    resolution: {integrity: sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==}
+    engines: {node: '>=20'}
+
+  p-reflect@3.1.0:
+    resolution: {integrity: sha512-3sG3UlpisPSaX+o7u2q01hIQmrpkvdl5GSO1ZwL7pfc5kHB2bPF0eFNCfYTrW1/LTUdgmPwBAvmT0Zr8eSmaAQ==}
+    engines: {node: '>=12'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
-
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
 
   parse-github-repo-url@1.4.1:
     resolution: {integrity: sha512-bSWyzBKqcSL4RrncTpGsEKoJ7H8a4L3++ifTAbTFeMHyq2wRV+42DGmQcHIrJIvdcacjIOxEuKH/w4tthF17gg==}
@@ -1724,6 +3064,10 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
+
   parse-ms@2.1.0:
     resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
     engines: {node: '>=6'}
@@ -1731,6 +3075,10 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse-npm-tarball-url@5.0.0:
+    resolution: {integrity: sha512-RIC1ICbP8vgo4Mt8v/FJNUo3yy/3gWs1Wf5vues+CMPrZPtGdwnAWTJxVgg3Kvk8CK4as8fpihOr/WDTMdifwg==}
+    engines: {node: '>=22.13'}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -1745,13 +3093,24 @@ packages:
     resolution: {integrity: sha512-gds5iRhSeOcDtj8gfWkRHLtZKTPsFVuh7utbjYtvnclw4XM+ffRzJrwqMhOD1PVqef7nBLmgsu1vIujjvAJrAw==}
     engines: {node: '>=4'}
 
+  path-absolute@2.0.0:
+    resolution: {integrity: sha512-yt9Q06veuarrNppU6hfzXdrrHGTtMMsjiixJKnaZilOkh47rYW7UYyOeWbOvSy+iAAC/2Lic7tOagFhxkbse2Q==}
+    engines: {node: '>=22.13'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-exists@5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+
+  path-is-network-drive@1.0.24:
+    resolution: {integrity: sha512-sux7NWiMq/ul8EEQTQbdM1m/zr+Rrq11/P9tEBgxMgTnVHS8f54tQm0kfrTxkvPNg/OVkRjHNgSia5VxnawOZg==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1776,9 +3135,16 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-strip-sep@1.0.21:
+    resolution: {integrity: sha512-V5Lvyhx0fE6/wEk/YseTtoRQIaD32cepnzrQ1b3kOzOxxDoSglry8IZ1b6LPObIeIbpC0+i9ygUsBNhkOttQKw==}
+
   path-temp@2.1.0:
     resolution: {integrity: sha512-cMMJTAZlion/RWRRC48UbrDymEIt+/YSD/l8NqjneyDw2rDOBQcP5yRkMB4CYGn47KMhZvbblBP7Z79OsMw72w==}
     engines: {node: '>=8.15'}
+
+  path-temp@3.0.0:
+    resolution: {integrity: sha512-5lJ7KUrynYR0TTTiU9SELstnX2fhz8qJ1rBfsEaI1IT3WDWcVkrg8T3lTUSJ/LJkIvrolbF0cFcq9shBC0jzxQ==}
+    engines: {node: '>=22.13'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1794,9 +3160,13 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkg-dir@5.0.0:
+    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
+    engines: {node: '>=10'}
 
   pkg-entry-points@1.1.1:
     resolution: {integrity: sha512-BhZa7iaPmB4b3vKIACoppyUoYn8/sFs17VJJtzrzPZvEnN2nqrgg911tdL65lA2m1ml6UI3iPeYbZQ4VXpn1mA==}
@@ -1804,6 +3174,10 @@ packages:
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preferred-pm@5.0.0:
+    resolution: {integrity: sha512-qs9WZBOIW4tXjxoYxUathIb53hcV3cjVpLJl8Y0h3QOiyqnbDzWmw0jvTI5YOw/RAkhDsB/sFVt9pYV+r6NP2A==}
+    engines: {node: '>=22.13'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1817,6 +3191,10 @@ packages:
   pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
+
+  pretty-bytes@7.1.0:
+    resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
+    engines: {node: '>=20'}
 
   pretty-ms@7.0.1:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
@@ -1832,6 +3210,10 @@ packages:
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -1849,8 +3231,15 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  promise-share@2.0.0:
+    resolution: {integrity: sha512-aJ7A/uh5IqCR9nyD4d8k0bp2xbR3NA2vp9FijCfiQmqmHDAUjf1OqZsBaUAe2RFnb3gQFuxJzjImL0TNeuUXQQ==}
+    engines: {node: '>=22.13'}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1863,6 +3252,14 @@ packages:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
 
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
+  quick-lru@7.3.0:
+    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
+    engines: {node: '>=18'}
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -1871,13 +3268,25 @@ packages:
     resolution: {integrity: sha512-kEmDUoYf/CDy8yZbLTmhB1X9kkjf9Q80PCNsDMb7ufrGd6zZSQA1+UyjrO+pZm5K/S4OXCWJeiIt1JA8kAsa6g==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  read-cmd-shim@6.0.0:
+    resolution: {integrity: sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   read-ini-file@4.0.0:
     resolution: {integrity: sha512-zz4qv/sKETv7nAkATqSJ9YMbKD8NXRPuA8d17VdYCuNYrVstB1S6UAMU6aytf5vRa9MESbZN7jLZdcmrOxz4gg==}
     engines: {node: '>=14.6'}
 
+  read-ini-file@5.0.0:
+    resolution: {integrity: sha512-MaUq//yy75pw4obW8dhqpmJ8EXnmuR/q1bFAoCrLhy5lVBu2MKg5X9ZJtXk9gVY4mkJb8eVP+RSEzB3y722EsA==}
+    engines: {node: '>=22.13'}
+
   read-yaml-file@2.1.0:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
     engines: {node: '>=10.13'}
+
+  read-yaml-file@3.0.0:
+    resolution: {integrity: sha512-7urDNDyx3oJt9NGkymzT3qudju76BoJhT6ICWclx6274zxMeSUOhyiceHscSBk4Lfbs0IYpjOjUwLkaOzrsJdQ==}
+    engines: {node: '>=22.13'}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -1886,6 +3295,10 @@ packages:
   realpath-missing@1.1.0:
     resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==}
     engines: {node: '>=10'}
+
+  realpath-missing@2.0.0:
+    resolution: {integrity: sha512-3pyjW3p6MbuafG62OJdz4R2WJgFVKtDdrSSq9pn0gJQnRGpgst/EboL5xQFXIdcFv4ncauY2mKu8puzBp6BRdQ==}
+    engines: {node: '>=22.13'}
 
   registry-auth-token@5.1.0:
     resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
@@ -1899,20 +3312,42 @@ packages:
     resolution: {integrity: sha512-WzP+O+XRF4AqhTDQK84FovY+TxHyC8J7QWoOwxnrvVjyHns417l1FUldboRhBYua5Pej6Yg/2jH1dEH2MRNHeA==}
     hasBin: true
 
+  rename-overwrite@7.0.1:
+    resolution: {integrity: sha512-tYzdjRCtRMiBg0xLqFEZH11T8HvpvhtiWE2Q8TWOpq0HAL07YBJEzC4pgfSWqLYziHCtlS16yB8tV4hFJrXvtA==}
+    engines: {node: '>=22.13'}
+
+  render-help@2.0.0:
+    resolution: {integrity: sha512-G2+pwTfPNVD4s3kgTey+ehVkZO6Cnsj9bDwG8VlxDjxLThPko8Nh33Egmqw/nVcksT5loHijaSdwf9g71id7wA==}
+    engines: {node: '>=22.13'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
+  resolve-link-target@3.0.0:
+    resolution: {integrity: sha512-WMnCSeV4WeH1F00qJmZ0mUKscxCYZTSbbTEfyJesRcr9Hs6e5rc0LX+7Pi7Q2GHoyW+vzCUQ0Y2GoyzjMc2DVw==}
+    engines: {node: '>=22.13'}
 
   resolve-package-path@4.0.3:
     resolution: {integrity: sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==}
     engines: {node: '>= 12'}
 
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
   reusify@1.1.0:
@@ -1921,6 +3356,11 @@ packages:
 
   rfc4648@1.5.4:
     resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
+
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -1931,6 +3371,18 @@ packages:
     resolution: {integrity: sha512-HqMFpUbWlf/tvcxBFNKnJyzc7Lk+XO3FGc3pbNBLqEbOz0gPLRgcrlS3UF4MfUrVlstOaP/q0kM6GVvi+LrLRg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  root-link-target@4.0.0:
+    resolution: {integrity: sha512-JvT9C9+Y9+AXoXuy17yLUxzvuBBYMFVtov6TnZu2RPyNm5KgH2CE8OJxhFRSG5g/ai7tefE00cvENGnWnAKFIQ==}
+    engines: {node: '>=22.13'}
+
+  rotated-array-set@3.0.0:
+    resolution: {integrity: sha512-G7689wvCM0szMFXUAhi3GfNGcSPlndg077cdRWoq7UegOAwfU2MJ0jD7s7jB+2ppKA75Kr/O0HwAP9+rRdBctg==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
+  run-groups@5.0.0:
+    resolution: {integrity: sha512-IpIAITIDF5m1FyL6ccgG2WbnXUpVKOOAgMuZz3E/MPV6s60YWnqu9P0ijSyDSMeLXQ+nTLdGevqIDOzup0BF6Q==}
+    engines: {node: '>=22.13'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -1945,8 +3397,34 @@ packages:
     resolution: {integrity: sha512-vdTshSQ2JsRCgT8eKZWNJIL26C6bVqy1SOmuCMlKHegVeo8KYRobRrefOdUq9OozSPUUiSxrylteeRmLOMFfWg==}
     engines: {node: '>=12'}
 
+  safe-execa@0.3.0:
+    resolution: {integrity: sha512-LMzgcWXnnL60sDuAzlmGehx7OHa4ajy0R/3djFOfnZwj4aksZUcdHfZgIIWLNcqverOAQJ2qOe7BDFm7Qpxd6Q==}
+    engines: {node: '>=22.13'}
+
+  safe-promise-defer@2.0.0:
+    resolution: {integrity: sha512-EXEr5wh/FntJnwiOdsZgR9eJ6pqfk8Nrh6BxMb+tupeIVXM7gHZt+AYpB6FvJ3EGp/5JQPyRCdh8mJsW2vN5/Q==}
+    engines: {node: '>=22.13'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-filename@1.6.4:
+    resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
+
+  semver-range-intersect@0.3.1:
+    resolution: {integrity: sha512-dZAVI9Gdl3uBvs1CBK1KHeCyiZDn4X14DW4C+QFQj+0k+l9L+pY1swt4KVt1hGU2dP77but4vx+N5XeYQsDteQ==}
+    engines: {node: '>=8.3.0'}
+
+  semver-utils@1.1.4:
+    resolution: {integrity: sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -1965,6 +3443,13 @@ packages:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
     engines: {node: '>= 0.4'}
 
+  shlex@3.0.0:
+    resolution: {integrity: sha512-jHPXQQk9d/QXCvJuLPYMOYWez3c43sORAgcIEoV7bFv5AJSJRAOyw5lQO12PMfd385qiLRCaDt7OtEzgrIGZUA==}
+
+  short-tree@3.0.0:
+    resolution: {integrity: sha512-Yd9NFs/o9QSoH4/wTjxk4Xe0+CIzitDRN1Qg7iBeTSejKjlCg/3PbgiRwDUVuaIxD0RRdv7Iz9jKr7e0HljtUg==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1975,9 +3460,17 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  slash@2.0.0:
+    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
+    engines: {node: '>=6'}
+
   slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -1987,6 +3480,10 @@ packages:
     resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
     engines: {node: '>= 10'}
 
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
   socks@2.8.4:
     resolution: {integrity: sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -1994,6 +3491,10 @@ packages:
   sort-keys@4.2.0:
     resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
     engines: {node: '>=8'}
+
+  sort-keys@6.0.0:
+    resolution: {integrity: sha512-ueSlHJMwpIw42CJ4B11Uxzh/S0p0AlOyiNktlv2KOu5e1JpUE6DlC4AAUjXqesHdBRv/g0wC9Q4vwq0NP2pA9w==}
+    engines: {node: '>=20'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2018,8 +3519,19 @@ packages:
   split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  ssri@12.0.0:
+    resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  ssri@13.0.1:
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
@@ -2061,6 +3573,10 @@ packages:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
 
+  strip-bom@5.0.0:
+    resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
+    engines: {node: '>=12'}
+
   strip-comments-strings@1.2.0:
     resolution: {integrity: sha512-zwF4bmnyEjZwRhaak9jUWNxc0DoeKBJ7lwSN/LEc8dQXZcUFG6auaaTQJokQWXopLdM3iTx01nQT8E4aL29DAQ==}
 
@@ -2076,10 +3592,6 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
-  strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2088,10 +3600,40 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  symlink-dir@10.0.1:
+    resolution: {integrity: sha512-34rLIwj9YzKr+2BTIpvp1/sYO8i3nmzTyrtx/iOKX2qWVEbqgWMfmkG41TDXiCaRi4I7dsHfTTnxUVi9p6RnIQ==}
+    engines: {node: '>=22.13'}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
+
+  temp-dir@2.0.0:
+    resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
+    engines: {node: '>=8'}
+
+  temporal-polyfill@0.3.2:
+    resolution: {integrity: sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==}
+
+  temporal-spec@0.3.1:
+    resolution: {integrity: sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==}
+
+  tempy@3.0.0:
+    resolution: {integrity: sha512-B2I9X7+o2wOaW4r/CWMkpOO9mdiTRCxXNgob6iGvPmfPWgH/KyUD6Uy5crtWBxIBe3YrNZKR2lSzv1JJKWD4vA==}
+    engines: {node: '>=14.16'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -2109,9 +3651,12 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyglobby@0.2.13:
-    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinylogic@2.0.0:
+    resolution: {integrity: sha512-dljTkiLLITtsjqBvTA1MRZQK/sGP4kI3UJKc3yA9fMzYbMF2RhcN04SeROVqJBIYYOoJMM8u0WDnhFwMSFQotw==}
 
   tinypool@1.0.2:
     resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
@@ -2133,12 +3678,34 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  touch@3.1.1:
+    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
+    hasBin: true
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
+
+  truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+
+  ts-toolbelt@9.6.0:
+    resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
+
+  ts-type@3.0.13:
+    resolution: {integrity: sha512-8SVH7wqDH06PA44UyzwyR3S6NGlweQ/U87glgxpwgn5Kr/xHOm1iljfrlBWQrpyIDYdCbHUFmK3a5lTINTq7xg==}
+    peerDependencies:
+      ts-toolbelt: ^9.6.0
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typanion@3.14.0:
+    resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2152,15 +3719,41 @@ packages:
     resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
     engines: {node: '>=8'}
 
+  type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
+  typedarray-dts@1.0.0:
+    resolution: {integrity: sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA==}
+
   typescript-memoize@1.1.1:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
+  uid-number@0.0.6:
+    resolution: {integrity: sha512-c461FXIljswCuscZn67xq9PpszkPT6RjheWFQTgCyabJrTUozElanb0YEqv2UGgk247YpcJkFBuSGNvBlpXM9w==}
+    deprecated: This package is no longer supported.
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -2169,12 +3762,24 @@ packages:
   unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
 
+  unique-filename@4.0.0:
+    resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   unique-slug@2.0.2:
     resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
+
+  unique-slug@5.0.0:
+    resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
+
+  unique-string@3.0.0:
+    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
+    engines: {node: '>=12'}
 
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
@@ -2183,14 +3788,28 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  untildify@4.0.0:
+    resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
+    engines: {node: '>=8'}
+
+  upath2@3.1.23:
+    resolution: {integrity: sha512-HQ7CivlKonWnq7m7VZuZHIDXXUCHOoCoIqgVyCk/z/wsuB/agGwGFhFjGSTArGlvBddiejrW4ChW6SwEMhAURQ==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validate-npm-package-name@4.0.0:
+    resolution: {integrity: sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
   validate-npm-package-name@5.0.0:
     resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
@@ -2199,6 +3818,14 @@ packages:
   validate-npm-package-name@6.0.0:
     resolution: {integrity: sha512-d7KLgL1LD3U3fgnvWEY1cQXoO/q6EQ1BSz48Sa149V/5zVTAbgmZIpyI8TRi6U9/JNyeYLlTKsEMPtLC27RFUg==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  validate-npm-package-name@7.0.2:
+    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  version-selector-type@3.0.0:
+    resolution: {integrity: sha512-PSvMIZS7C1MuVNBXl/CDG2pZq8EXy/NW2dHIdm3bVP5N0PC8utDK8ttXLXj44Gn3J0lQE3U7Mpm1estAOd+eiA==}
+    engines: {node: '>=10.13'}
 
   vite-node@3.1.4:
     resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
@@ -2280,6 +3907,10 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  which-pm@4.0.0:
+    resolution: {integrity: sha512-kLoLJ/y2o0GnU8ZNgI5/nlCbyjpUlqtaJQjMrzR2sKyQQ3BcJJ61oSOdZWIrfoScunyZS5w9U0wyFb0Bij9cyg==}
+    engines: {node: '>=22.13'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2327,9 +3958,17 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   write-yaml-file@5.0.0:
     resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
     engines: {node: '>=16.14'}
+
+  write-yaml-file@6.0.0:
+    resolution: {integrity: sha512-WG6oDbTuNkiDr0sjYiuV715ZBUYOZVf838wu+7M0WAbkCmv5z2P7OW9gCfgEclXPwP08r5CvBtEyqV7vht070A==}
+    engines: {node: '>=22.13'}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2337,6 +3976,15 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -2358,11 +4006,19 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
 snapshots:
+
+  '@arcanis/slice-ansi@1.1.1':
+    dependencies:
+      grapheme-splitter: 1.0.4
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2464,48 +4120,36 @@ snapshots:
   '@esbuild/win32-x64@0.25.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.7.0(eslint@9.27.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.3.0)':
     dependencies:
-      eslint: 9.27.0
+      eslint: 10.3.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.12.1': {}
+  '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.20.0':
+  '@eslint/config-array@0.23.5':
     dependencies:
-      '@eslint/object-schema': 2.1.6
+      '@eslint/object-schema': 3.0.5
       debug: 4.4.1
-      minimatch: 3.1.2
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.2.2': {}
+  '@eslint/config-helpers@0.5.5':
+    dependencies:
+      '@eslint/core': 1.2.1
 
-  '@eslint/core@0.14.0':
+  '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.4.1
-      espree: 10.3.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@eslint/js@9.27.0': {}
 
-  '@eslint/object-schema@2.1.6': {}
+  '@eslint/object-schema@3.0.5': {}
 
-  '@eslint/plugin-kit@0.3.1':
+  '@eslint/plugin-kit@0.7.1':
     dependencies:
-      '@eslint/core': 0.14.0
+      '@eslint/core': 1.2.1
       levn: 0.4.1
 
   '@gar/promisify@1.1.3': {}
@@ -2534,7 +4178,19 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@lazy-node/types-path@1.0.3(ts-toolbelt@9.6.0)':
+    dependencies:
+      '@types/node': 22.15.21
+      ts-type: 3.0.13(ts-toolbelt@9.6.0)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - ts-toolbelt
 
   '@manypkg/find-root@2.2.3':
     dependencies:
@@ -2549,7 +4205,25 @@ snapshots:
     dependencies:
       fast-glob: 3.3.3
       jju: 1.4.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2563,9 +4237,23 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@npmcli/agent@3.0.0':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 10.4.3
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
+      semver: 7.7.2
+
+  '@npmcli/fs@4.0.0':
+    dependencies:
       semver: 7.7.2
 
   '@npmcli/git@6.0.3':
@@ -2669,6 +4357,138 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@pnpm/agent.client@1.0.4(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.cafs': 1100.1.3
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+
+  '@pnpm/bins.linker@1100.0.5(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/bins.resolver': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fs.read-modules-dir': 1100.0.1
+      '@pnpm/logger': 5.2.0
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/pkg-manifest.utils': 1100.1.2(@pnpm/logger@5.2.0)
+      '@pnpm/types': 1101.1.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.4(@pnpm/logger@5.2.0)
+      '@zkochan/cmd-shim': 9.0.3
+      '@zkochan/rimraf': 4.0.0
+      bin-links: 6.0.0
+      is-subdir: 2.0.0
+      is-windows: 1.0.2
+      normalize-path: 3.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.7.2
+      symlink-dir: 10.0.1
+
+  '@pnpm/bins.remover@1100.0.3(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/bins.resolver': 1100.0.3
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/types': 1101.1.0
+      '@zkochan/rimraf': 4.0.0
+      cmd-extension: 2.0.0
+      is-windows: 1.0.2
+
+  '@pnpm/bins.resolver@1100.0.3':
+    dependencies:
+      '@pnpm/types': 1101.1.0
+      is-subdir: 2.0.0
+      tinyglobby: 0.2.16
+
+  '@pnpm/building.after-install@1101.0.11(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/bins.linker': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/building.pkg-requires-build': 1100.0.3
+      '@pnpm/building.policy': 1100.0.4
+      '@pnpm/config.normalize-registries': 1100.0.3
+      '@pnpm/config.reader': 1101.3.0(@pnpm/logger@5.2.0)
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.graph-hasher': 1100.1.5
+      '@pnpm/deps.graph-sequencer': 1100.0.0
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/exec.lifecycle': 1100.0.9(@pnpm/logger@5.2.0)(typanion@3.14.0)
+      '@pnpm/installing.context': 1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/installing.modules-yaml': 1100.0.4
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/lockfile.walker': 1100.0.5
+      '@pnpm/logger': 5.2.0
+      '@pnpm/npm-package-arg': 2.0.0
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/store.cafs': 1100.1.3
+      '@pnpm/store.connection-manager': 1100.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      load-json-file: 7.0.1
+      p-limit: 7.3.0
+      run-groups: 5.0.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/building.during-install@1101.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/bins.linker': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/config.reader': 1101.3.0(@pnpm/logger@5.2.0)
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.graph-hasher': 1100.1.5
+      '@pnpm/deps.graph-sequencer': 1100.0.0
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/exec.lifecycle': 1100.0.9(@pnpm/logger@5.2.0)(typanion@3.14.0)
+      '@pnpm/fs.hard-link-dir': 1100.0.1(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/patching.apply-patch': 1100.0.0(@pnpm/logger@5.2.0)
+      '@pnpm/patching.types': 1100.0.0
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/types': 1101.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      p-defer: 4.0.1
+      ramda: '@pnpm/ramda@0.28.1'
+      run-groups: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typanion
+
+  '@pnpm/building.pkg-requires-build@1100.0.3':
+    dependencies:
+      '@pnpm/types': 1101.1.0
+
+  '@pnpm/building.policy@1100.0.4':
+    dependencies:
+      '@pnpm/config.version-policy': 1100.0.3
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/types': 1101.1.0
+
+  '@pnpm/byline@1.0.0': {}
+
+  '@pnpm/catalogs.config@1100.0.0':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+
+  '@pnpm/catalogs.protocol-parser@1100.0.0': {}
+
+  '@pnpm/catalogs.resolver@1100.0.0':
+    dependencies:
+      '@pnpm/catalogs.protocol-parser': 1100.0.0
+      '@pnpm/error': 1100.0.0
+
+  '@pnpm/catalogs.types@1100.0.0': {}
+
   '@pnpm/cli-meta@6.0.1':
     dependencies:
       '@pnpm/types': 10.1.0
@@ -2688,9 +4508,115 @@ snapshots:
       chalk: 4.1.2
       load-json-file: 6.2.0
 
+  '@pnpm/cli.command@1100.0.1':
+    dependencies:
+      '@pnpm/tabtab': 0.5.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@pnpm/cli.common-cli-options-help@1100.0.1': {}
+
+  '@pnpm/cli.meta@1100.0.3':
+    dependencies:
+      '@pnpm/types': 1101.1.0
+      load-json-file: 7.0.1
+
+  '@pnpm/cli.utils@1101.0.3(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/cli.meta': 1100.0.3
+      '@pnpm/config.package-is-installable': 1100.0.4(@pnpm/logger@5.2.0)
+      '@pnpm/error': 1100.0.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/pkg-manifest.utils': 1100.1.2(@pnpm/logger@5.2.0)
+      '@pnpm/types': 1101.1.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.4(@pnpm/logger@5.2.0)
+      chalk: 5.6.2
+      load-json-file: 7.0.1
+
+  '@pnpm/colorize-semver-diff@2.0.0':
+    dependencies:
+      chalk: 5.6.2
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/config.env-replace@3.0.0': {}
+
+  '@pnpm/config.env-replace@3.0.2': {}
+
+  '@pnpm/config.matcher@1100.0.1':
+    dependencies:
+      escape-string-regexp: 5.0.0
+
+  '@pnpm/config.nerf-dart@1.0.1': {}
+
+  '@pnpm/config.normalize-registries@1100.0.3':
+    dependencies:
+      '@pnpm/types': 1101.1.0
+      normalize-registry-url: 2.0.1
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/config.package-is-installable@1100.0.4(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/cli.meta': 1100.0.3
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/engine.runtime.system-node-version': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+      detect-libc: 2.0.4
+      execa: safe-execa@0.3.0
+      memoize: 10.2.0
+      semver: 7.7.2
+
+  '@pnpm/config.parse-overrides@1100.0.1':
+    dependencies:
+      '@pnpm/catalogs.resolver': 1100.0.0
+      '@pnpm/catalogs.types': 1100.0.0
+      '@pnpm/error': 1100.0.0
+      '@pnpm/resolving.parse-wanted-dependency': 1100.0.1
+
+  '@pnpm/config.pick-registry-for-package@1100.0.3':
+    dependencies:
+      '@pnpm/types': 1101.1.0
+
+  '@pnpm/config.reader@1101.3.0(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/catalogs.config': 1100.0.0
+      '@pnpm/catalogs.types': 1100.0.0
+      '@pnpm/config.env-replace': 3.0.2
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/error': 1100.0.0
+      '@pnpm/hooks.pnpmfile': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/network.git-utils': 1100.0.1
+      '@pnpm/pkg-manifest.utils': 1100.1.2(@pnpm/logger@5.2.0)
+      '@pnpm/text.naming-cases': 1100.0.1
+      '@pnpm/types': 1101.1.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.4(@pnpm/logger@5.2.0)
+      '@pnpm/workspace.workspace-manifest-reader': 1100.0.3
+      better-path-resolve: 2.0.0
+      camelcase: 9.0.0
+      camelcase-keys: 10.0.2
+      can-write-to-dir: 2.0.0
+      ci-info: 4.4.0
+      is-subdir: 2.0.0
+      is-windows: 1.0.2
+      lodash.kebabcase: 4.1.1
+      normalize-registry-url: 2.0.1
+      path-absolute: 2.0.0
+      path-name: 1.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      read-ini-file: 5.0.0
+      realpath-missing: 2.0.0
+      semver: 7.7.2
+
+  '@pnpm/config.version-policy@1100.0.3':
+    dependencies:
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/types': 1101.1.0
+      semver: 7.7.2
 
   '@pnpm/config@21.4.0(@pnpm/logger@5.2.0)':
     dependencies:
@@ -2721,6 +4647,10 @@ snapshots:
 
   '@pnpm/constants@10.0.0': {}
 
+  '@pnpm/constants@1001.3.1': {}
+
+  '@pnpm/constants@1100.0.0': {}
+
   '@pnpm/constants@8.0.0': {}
 
   '@pnpm/core-loggers@10.0.1(@pnpm/logger@5.2.0)':
@@ -2728,9 +4658,34 @@ snapshots:
       '@pnpm/logger': 5.2.0
       '@pnpm/types': 10.1.0
 
+  '@pnpm/core-loggers@1100.0.2(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+
   '@pnpm/crypto.base32-hash@3.0.0':
     dependencies:
       rfc4648: 1.5.4
+
+  '@pnpm/crypto.hash@1100.0.1':
+    dependencies:
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      ssri: 13.0.1
+
+  '@pnpm/crypto.integrity@1100.0.0':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+
+  '@pnpm/crypto.object-hasher@1100.0.0':
+    dependencies:
+      object-hash: 3.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/crypto.shasums-file@1100.0.1':
+    dependencies:
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.types': 1100.0.1
 
   '@pnpm/dedupe.issues-renderer@2.0.0':
     dependencies:
@@ -2763,6 +4718,235 @@ snapshots:
       stacktracey: 2.1.8
       string-length: 4.0.2
 
+  '@pnpm/deps.graph-builder@1100.0.8(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config.package-is-installable': 1100.0.4(@pnpm/logger@5.2.0)
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.graph-hasher': 1100.1.5
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/installing.modules-yaml': 1100.0.4
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/logger': 5.2.0
+      '@pnpm/patching.config': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/patching.types': 1100.0.0
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/types': 1101.1.0
+      path-exists: 5.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/deps.graph-hasher@1100.1.5':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/crypto.object-hasher': 1100.0.0
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      detect-libc: 2.0.4
+
+  '@pnpm/deps.graph-sequencer@1100.0.0': {}
+
+  '@pnpm/deps.inspection.commands@1100.2.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(@yarnpkg/core@4.7.0(typanion@3.14.0))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/cli.command': 1100.0.1
+      '@pnpm/cli.common-cli-options-help': 1100.0.1
+      '@pnpm/cli.utils': 1101.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/colorize-semver-diff': 2.0.0
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/config.pick-registry-for-package': 1100.0.3
+      '@pnpm/config.reader': 1101.3.0(@pnpm/logger@5.2.0)
+      '@pnpm/deps.inspection.list': 1100.0.9(@pnpm/logger@5.2.0)
+      '@pnpm/deps.inspection.outdated': 1100.0.14(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(@yarnpkg/core@4.7.0(typanion@3.14.0))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/deps.inspection.peers-checker': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/deps.inspection.peers-issues-renderer': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/global.commands': 1100.0.16(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(@yarnpkg/core@4.7.0(typanion@3.14.0))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/global.packages': 1100.0.3
+      '@pnpm/installing.modules-yaml': 1100.0.4
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/network.auth-header': 1100.0.2
+      '@pnpm/network.fetch': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/npm-package-arg': 2.0.0
+      '@pnpm/resolving.default-resolver': 1100.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/resolving.npm-resolver': 1101.1.0(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/resolving.registry.types': 1100.0.3
+      '@pnpm/semver-diff': 2.0.0
+      '@pnpm/store.path': 1100.0.1
+      '@pnpm/types': 1101.1.0
+      '@zkochan/table': 2.0.1
+      chalk: 5.6.2
+      hosted-git-info: '@pnpm/hosted-git-info@1.0.0'
+      open: 7.4.2
+      ramda: '@pnpm/ramda@0.28.1'
+      render-help: 2.0.0
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+      - '@yarnpkg/core'
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/deps.inspection.list@1100.0.9(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/deps.inspection.tree-builder': 1100.0.8(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/text.tree-renderer': 1100.0.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      '@pnpm/workspace.project-manifest-reader': 1100.0.4(@pnpm/logger@5.2.0)
+      chalk: 5.6.2
+      p-limit: 7.3.0
+      ramda: '@pnpm/ramda@0.28.1'
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/deps.inspection.outdated@1100.0.14(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(@yarnpkg/core@4.7.0(typanion@3.14.0))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/catalogs.resolver': 1100.0.0
+      '@pnpm/catalogs.types': 1100.0.0
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/config.parse-overrides': 1100.0.1
+      '@pnpm/config.pick-registry-for-package': 1100.0.3
+      '@pnpm/config.version-policy': 1100.0.3
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/hooks.read-package-hook': 1100.0.3(@yarnpkg/core@4.7.0(typanion@3.14.0))
+      '@pnpm/installing.client': 1100.0.14(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/logger': 5.2.0
+      '@pnpm/pkg-manifest.utils': 1100.1.2(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.npm-resolver': 1101.1.0(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/types': 1101.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+      - '@yarnpkg/core'
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/deps.inspection.peers-checker@1100.0.7(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/config.parse-overrides': 1100.0.1
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.walker': 1100.0.5
+      '@pnpm/types': 1101.1.0
+      semver: 7.7.2
+      semver-range-intersect: 0.3.1
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/deps.inspection.peers-issues-renderer@1100.0.1':
+    dependencies:
+      '@pnpm/types': 1101.1.0
+      chalk: 5.6.2
+
+  '@pnpm/deps.inspection.tree-builder@1100.0.8(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/config.normalize-registries': 1100.0.3
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/fs.read-modules-dir': 1100.0.1
+      '@pnpm/installing.modules-yaml': 1100.0.4
+      '@pnpm/lockfile.detect-dep-types': 1100.0.5
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/npm-package-arg': 2.0.0
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/store.cafs': 1100.1.3
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      load-json-file: 7.0.1
+      normalize-path: 3.0.0
+      path-absolute: 2.0.0
+      realpath-missing: 2.0.0
+      resolve-link-target: 3.0.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/deps.path@1100.0.3':
+    dependencies:
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/types': 1101.1.0
+      semver: 7.7.2
+
+  '@pnpm/deps.peer-range@1100.0.1':
+    dependencies:
+      semver: 7.7.2
+
+  '@pnpm/engine.runtime.bun-resolver@1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/crypto.shasums-file': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.binary-fetcher': 1101.0.5(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/resolving.npm-resolver': 1101.1.0(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/engine.runtime.deno-resolver@1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/crypto.shasums-file': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.binary-fetcher': 1101.0.5(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/resolving.npm-resolver': 1101.1.0(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/engine.runtime.node-resolver@1101.0.7(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config.reader': 1101.3.0(@pnpm/logger@5.2.0)
+      '@pnpm/crypto.shasums-file': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      semver: 7.7.2
+      version-selector-type: 3.0.0
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/engine.runtime.system-node-version@1100.0.3':
+    dependencies:
+      '@pnpm/cli.meta': 1100.0.3
+      execa: safe-execa@0.3.0
+      memoize: 10.2.0
+
+  '@pnpm/error@1000.1.0':
+    dependencies:
+      '@pnpm/constants': 1001.3.1
+
+  '@pnpm/error@1100.0.0':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
+
   '@pnpm/error@6.0.1':
     dependencies:
       '@pnpm/constants': 8.0.0
@@ -2771,11 +4955,128 @@ snapshots:
     dependencies:
       '@pnpm/constants': 10.0.0
 
+  '@pnpm/exec.lifecycle@1100.0.9(@pnpm/logger@5.2.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/bins.linker': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.directory-fetcher': 1100.0.8(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/npm-lifecycle': 1100.0.0-1(typanion@3.14.0)
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/store.cafs-types': 1100.0.1
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/types': 1101.1.0
+      chalk: 5.6.2
+      is-windows: 1.0.2
+      path-exists: 5.0.0
+      run-groups: 5.0.0
+      shlex: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typanion
+
+  '@pnpm/exec.prepare-package@1100.0.9(@pnpm/logger@5.2.0)(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/exec.lifecycle': 1100.0.9(@pnpm/logger@5.2.0)(typanion@3.14.0)
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/types': 1101.1.0
+      '@zkochan/rimraf': 4.0.0
+      execa: safe-execa@0.3.0
+      preferred-pm: 5.0.0(ts-toolbelt@9.6.0)
+      ramda: '@pnpm/ramda@0.28.1'
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
   '@pnpm/fetcher-base@16.0.1':
     dependencies:
       '@pnpm/resolver-base': 12.0.1
       '@pnpm/types': 10.1.0
       '@types/ssri': 7.1.5
+
+  '@pnpm/fetching.binary-fetcher@1101.0.5(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      adm-zip: 0.5.17
+      is-subdir: 2.0.0
+      rename-overwrite: 7.0.1
+      ssri: 13.0.1
+      tempy: 3.0.0
+
+  '@pnpm/fetching.directory-fetcher@1100.0.8(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/building.pkg-requires-build': 1100.0.3
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fs.packlist': 1100.0.1
+      '@pnpm/logger': 5.2.0
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.cafs-types': 1100.0.1
+      '@pnpm/types': 1101.1.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.4(@pnpm/logger@5.2.0)
+
+  '@pnpm/fetching.fetcher-base@1100.1.3':
+    dependencies:
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      '@types/ssri': 7.1.5
+
+  '@pnpm/fetching.git-fetcher@1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/exec.prepare-package': 1100.0.9(@pnpm/logger@5.2.0)(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fs.packlist': 1100.0.1
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      '@zkochan/rimraf': 4.0.0
+      execa: safe-execa@0.3.0
+    transitivePeerDependencies:
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/fetching.pick-fetcher@1100.0.6':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.cafs-types': 1100.0.1
+
+  '@pnpm/fetching.tarball-fetcher@1101.0.6(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/error': 1100.0.0
+      '@pnpm/exec.prepare-package': 1100.0.9(@pnpm/logger@5.2.0)(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/fs.packlist': 1100.0.1
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      '@zkochan/retry': 0.2.0
+      lodash.throttle: 4.1.1
+      p-map-values: 0.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+    transitivePeerDependencies:
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/fetching.types@1100.0.1':
+    dependencies:
+      '@zkochan/retry': 0.2.0
 
   '@pnpm/find-workspace-dir@7.0.3':
     dependencies:
@@ -2790,26 +5091,569 @@ snapshots:
       fast-glob: 3.3.3
       p-filter: 2.1.0
 
+  '@pnpm/fs.graceful-fs@1100.1.0':
+    dependencies:
+      graceful-fs: 4.2.11
+
+  '@pnpm/fs.hard-link-dir@1100.0.1(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/logger': 5.2.0
+      path-temp: 3.0.0
+      rename-overwrite: 7.0.1
+
+  '@pnpm/fs.indexed-pkg-importer@1100.0.6(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.controller-types': 1100.0.6
+      '@reflink/reflink': 0.1.19
+      '@zkochan/rimraf': 4.0.0
+      fs-extra: 11.3.5
+      make-empty-dir: 4.0.0
+      p-limit: 7.3.0
+      path-temp: 3.0.0
+      rename-overwrite: 7.0.1
+      sanitize-filename: 1.6.4
+
+  '@pnpm/fs.packlist@1100.0.1':
+    dependencies:
+      npm-packlist: 10.0.4
+
   '@pnpm/fs.packlist@2.0.0':
     dependencies:
       npm-packlist: 5.1.3
+
+  '@pnpm/fs.read-modules-dir@1100.0.1':
+    dependencies:
+      graceful-fs: 4.2.11
+
+  '@pnpm/fs.symlink-dependency@1100.0.3(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+      symlink-dir: 10.0.1
 
   '@pnpm/git-utils@2.0.0':
     dependencies:
       execa: safe-execa@0.1.2
 
+  '@pnpm/global.commands@1100.0.16(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(@yarnpkg/core@4.7.0(typanion@3.14.0))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/bins.linker': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/bins.remover': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/bins.resolver': 1100.0.3
+      '@pnpm/cli.command': 1100.0.1
+      '@pnpm/cli.utils': 1101.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/config.reader': 1101.3.0(@pnpm/logger@5.2.0)
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.inspection.list': 1100.0.9(@pnpm/logger@5.2.0)
+      '@pnpm/error': 1100.0.0
+      '@pnpm/global.packages': 1100.0.3
+      '@pnpm/installing.deps-installer': 1101.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(@yarnpkg/core@4.7.0(typanion@3.14.0))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/store.connection-manager': 1100.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      is-subdir: 2.0.0
+      symlink-dir: 10.0.1
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+      - '@pnpm/worker'
+      - '@yarnpkg/core'
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/global.packages@1100.0.3':
+    dependencies:
+      '@pnpm/bins.resolver': 1100.0.3
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+
   '@pnpm/graceful-fs@4.0.0':
     dependencies:
       graceful-fs: 4.2.11
+
+  '@pnpm/hooks.pnpmfile@1100.0.7(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/types': 1101.1.0
+      chalk: 5.6.2
+      path-absolute: 2.0.0
+
+  '@pnpm/hooks.read-package-hook@1100.0.3(@yarnpkg/core@4.7.0(typanion@3.14.0))':
+    dependencies:
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/config.parse-overrides': 1100.0.1
+      '@pnpm/deps.peer-range': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/resolving.parse-wanted-dependency': 1100.0.1
+      '@pnpm/types': 1101.1.0
+      '@yarnpkg/extensions': 2.0.6(@yarnpkg/core@4.7.0(typanion@3.14.0))
+      normalize-path: 3.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@yarnpkg/core'
+
+  '@pnpm/hooks.types@1100.0.6':
+    dependencies:
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.cafs-types': 1100.0.1
+      '@pnpm/types': 1101.1.0
 
   '@pnpm/hooks.types@2.0.2':
     dependencies:
       '@pnpm/lockfile-types': 7.1.0
       '@pnpm/types': 10.1.0
 
+  '@pnpm/hosted-git-info@1.0.0':
+    dependencies:
+      lru-cache: 6.0.0
+
+  '@pnpm/installing.client@1100.0.14(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/engine.runtime.node-resolver': 1101.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/fetching.binary-fetcher': 1101.0.5(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/fetching.directory-fetcher': 1100.0.8(@pnpm/logger@5.2.0)
+      '@pnpm/fetching.git-fetcher': 1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/fetching.tarball-fetcher': 1101.0.6(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/network.auth-header': 1100.0.2
+      '@pnpm/network.fetch': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.default-resolver': 1100.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+      - '@pnpm/worker'
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/installing.context@1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/installing.modules-yaml': 1100.0.4
+      '@pnpm/installing.read-projects-context': 1100.0.8(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.controller': 1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/types': 1101.1.0
+      path-absolute: 2.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+
+  '@pnpm/installing.deps-installer@1101.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(@yarnpkg/core@4.7.0(typanion@3.14.0))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/agent.client': 1.0.4(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/bins.linker': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/bins.remover': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/building.after-install': 1101.0.11(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/building.during-install': 1101.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(typanion@3.14.0)
+      '@pnpm/building.policy': 1100.0.4
+      '@pnpm/catalogs.protocol-parser': 1100.0.0
+      '@pnpm/catalogs.resolver': 1100.0.0
+      '@pnpm/catalogs.types': 1100.0.0
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/config.normalize-registries': 1100.0.3
+      '@pnpm/config.parse-overrides': 1100.0.1
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/crypto.object-hasher': 1100.0.0
+      '@pnpm/deps.graph-hasher': 1100.1.5
+      '@pnpm/deps.graph-sequencer': 1100.0.0
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/exec.lifecycle': 1100.0.9(@pnpm/logger@5.2.0)(typanion@3.14.0)
+      '@pnpm/fs.read-modules-dir': 1100.0.1
+      '@pnpm/fs.symlink-dependency': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/hooks.read-package-hook': 1100.0.3(@yarnpkg/core@4.7.0(typanion@3.14.0))
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/installing.context': 1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/installing.deps-resolver': 1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(typanion@3.14.0)
+      '@pnpm/installing.deps-restorer': 1101.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(typanion@3.14.0)
+      '@pnpm/installing.linking.direct-dep-linker': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/installing.linking.hoist': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/installing.linking.modules-cleaner': 1100.1.0(@pnpm/logger@5.2.0)
+      '@pnpm/installing.modules-yaml': 1100.0.4
+      '@pnpm/installing.package-requester': 1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/lockfile.filtering': 1100.1.0(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.preferred-versions': 1100.0.8(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.pruner': 1100.0.5
+      '@pnpm/lockfile.settings-checker': 1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/lockfile.to-pnp': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/lockfile.verification': 1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/lockfile.walker': 1100.0.5
+      '@pnpm/logger': 5.2.0
+      '@pnpm/npm-package-arg': 2.0.0
+      '@pnpm/patching.config': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/pkg-manifest.utils': 1100.1.2(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.parse-wanted-dependency': 1100.0.1
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      '@pnpm/workspace.project-manifest-reader': 1100.0.4(@pnpm/logger@5.2.0)
+      '@zkochan/rimraf': 4.0.0
+      enquirer: 2.4.1
+      is-inner-link: 5.0.0
+      is-subdir: 2.0.0
+      load-json-file: 7.0.1
+      normalize-path: 3.0.0
+      p-filter: 4.1.0
+      p-limit: 7.3.0
+      path-absolute: 2.0.0
+      path-exists: 5.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      run-groups: 5.0.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@yarnpkg/core'
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/installing.deps-resolver@1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/catalogs.resolver': 1100.0.0
+      '@pnpm/catalogs.types': 1100.0.0
+      '@pnpm/config.version-policy': 1100.0.3
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.graph-hasher': 1100.1.5
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/deps.peer-range': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.pick-fetcher': 1100.0.6
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/lockfile.preferred-versions': 1100.0.8(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.pruner': 1100.0.5
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/logger': 5.2.0
+      '@pnpm/patching.config': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/patching.types': 1100.0.0
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/pkg-manifest.utils': 1100.1.2(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.npm-resolver': 1101.1.0(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      '@pnpm/workspace.spec-parser': 1100.0.0
+      '@yarnpkg/core': 4.5.0(typanion@3.14.0)
+      graph-cycles: 3.0.0
+      is-inner-link: 5.0.0
+      is-subdir: 2.0.0
+      normalize-path: 3.0.0
+      p-defer: 4.0.1
+      path-exists: 5.0.0
+      promise-share: 2.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      rename-overwrite: 7.0.1
+      safe-promise-defer: 2.0.0
+      semver: 7.7.2
+      semver-range-intersect: 0.3.1
+      version-selector-type: 3.0.0
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+      - typanion
+
+  '@pnpm/installing.deps-restorer@1101.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/bins.linker': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/building.during-install': 1101.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(typanion@3.14.0)
+      '@pnpm/building.policy': 1100.0.4
+      '@pnpm/config.package-is-installable': 1100.0.4(@pnpm/logger@5.2.0)
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.graph-builder': 1100.0.8(@pnpm/logger@5.2.0)
+      '@pnpm/deps.graph-hasher': 1100.1.5
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/exec.lifecycle': 1100.0.9(@pnpm/logger@5.2.0)(typanion@3.14.0)
+      '@pnpm/fs.symlink-dependency': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/installing.linking.direct-dep-linker': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/installing.linking.hoist': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/installing.linking.modules-cleaner': 1100.1.0(@pnpm/logger@5.2.0)
+      '@pnpm/installing.linking.real-hoist': 1100.0.7(typanion@3.14.0)
+      '@pnpm/installing.modules-yaml': 1100.0.4
+      '@pnpm/installing.package-requester': 1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/lockfile.filtering': 1100.1.0(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.to-pnp': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/logger': 5.2.0
+      '@pnpm/patching.config': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/types': 1101.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      '@pnpm/workspace.project-manifest-reader': 1100.0.4(@pnpm/logger@5.2.0)
+      '@zkochan/rimraf': 4.0.0
+      p-limit: 7.3.0
+      path-absolute: 2.0.0
+      path-exists: 5.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      realpath-missing: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typanion
+
+  '@pnpm/installing.linking.direct-dep-linker@1100.0.3(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/fs.read-modules-dir': 1100.0.1
+      '@pnpm/fs.symlink-dependency': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@zkochan/rimraf': 4.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      resolve-link-target: 3.0.0
+
+  '@pnpm/installing.linking.hoist@1100.0.5(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/bins.linker': 1100.0.5(@pnpm/logger@5.2.0)
+      '@pnpm/config.matcher': 1100.0.1
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/util.lex-comparator': 3.0.2
+      is-subdir: 2.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      resolve-link-target: 3.0.0
+      symlink-dir: 10.0.1
+
+  '@pnpm/installing.linking.modules-cleaner@1100.1.0(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/bins.remover': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/fs.read-modules-dir': 1100.0.1
+      '@pnpm/lockfile.filtering': 1100.1.0(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/types': 1101.1.0
+      '@zkochan/rimraf': 4.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/installing.linking.real-hoist@1100.0.7(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@yarnpkg/nm': 4.0.7(typanion@3.14.0)
+    transitivePeerDependencies:
+      - typanion
+
+  '@pnpm/installing.modules-yaml@1100.0.4':
+    dependencies:
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      is-windows: 1.0.2
+      ramda: '@pnpm/ramda@0.28.1'
+      read-yaml-file: 3.0.0
+
+  '@pnpm/installing.package-requester@1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/config.package-is-installable': 1100.0.4(@pnpm/logger@5.2.0)
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fetching.pick-fetcher': 1100.0.6
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/logger': 5.2.0
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.cafs': 1100.1.3
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      detect-libc: 2.0.4
+      load-json-file: 7.0.1
+      p-defer: 4.0.1
+      p-limit: 7.3.0
+      p-queue: 9.2.0
+      promise-share: 2.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.7.2
+      ssri: 13.0.1
+
+  '@pnpm/installing.read-projects-context@1100.0.8(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config.normalize-registries': 1100.0.3
+      '@pnpm/installing.modules-yaml': 1100.0.4
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+      path-absolute: 2.0.0
+      realpath-missing: 2.0.0
+
   '@pnpm/lockfile-types@7.1.0':
     dependencies:
       '@pnpm/types': 10.1.0
+
+  '@pnpm/lockfile.detect-dep-types@1100.0.5':
+    dependencies:
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/types': 1101.1.0
+
+  '@pnpm/lockfile.filtering@1100.1.0(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config.package-is-installable': 1100.0.4(@pnpm/logger@5.2.0)
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/lockfile.walker': 1100.0.5
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/lockfile.fs@1100.0.7(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/lockfile.merger': 1100.0.5
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/logger': 5.2.0
+      '@pnpm/network.git-utils': 1100.0.1
+      '@pnpm/object.key-sorting': 1100.0.0
+      '@pnpm/types': 1101.1.0
+      '@zkochan/rimraf': 4.0.0
+      comver-to-semver: 2.0.0
+      js-yaml: '@zkochan/js-yaml@0.0.11'
+      normalize-path: 3.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.7.2
+      strip-bom: 5.0.0
+      write-file-atomic: 7.0.1
+
+  '@pnpm/lockfile.merger@1100.0.5':
+    dependencies:
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/types': 1101.1.0
+      comver-to-semver: 2.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.7.2
+
+  '@pnpm/lockfile.preferred-versions@1100.0.8(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/pkg-manifest.utils': 1100.1.2(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      version-selector-type: 3.0.0
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/lockfile.pruner@1100.0.5':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/types': 1101.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/lockfile.settings-checker@1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/catalogs.types': 1100.0.0
+      '@pnpm/config.parse-overrides': 1100.0.1
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/lockfile.verification': 1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      p-map-values: 0.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+      - '@pnpm/worker'
+
+  '@pnpm/lockfile.to-pnp@1100.0.7(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/lockfile.fs': 1100.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+      '@yarnpkg/pnp': 4.1.5
+      normalize-path: 3.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/lockfile.types@1100.0.5':
+    dependencies:
+      '@pnpm/patching.types': 1100.0.0
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+
+  '@pnpm/lockfile.utils@1100.0.7':
+    dependencies:
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      get-npm-tarball-url: 2.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/lockfile.verification@1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/catalogs.types': 1100.0.0
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/installing.context': 1100.0.9(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/logger': 5.2.0
+      '@pnpm/pkg-manifest.reader': 1100.0.3
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      p-every: 2.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.7.2
+      version-selector-type: 3.0.0
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+
+  '@pnpm/lockfile.walker@1100.0.5':
+    dependencies:
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/lockfile.types': 1100.0.5
+      '@pnpm/types': 1101.1.0
 
   '@pnpm/logger@5.2.0':
     dependencies:
@@ -2828,9 +5672,32 @@ snapshots:
     dependencies:
       escape-string-regexp: 4.0.0
 
+  '@pnpm/network.auth-header@1100.0.2':
+    dependencies:
+      '@pnpm/config.nerf-dart': 1.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/types': 1101.1.0
+
   '@pnpm/network.ca-file@1.0.2':
     dependencies:
       graceful-fs: 4.2.10
+
+  '@pnpm/network.fetch@1100.0.3(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/config.nerf-dart': 1.0.1
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+      '@zkochan/retry': 0.2.0
+      lru-cache: 11.3.6
+      socks: 2.8.4
+      undici: 7.25.0
+
+  '@pnpm/network.git-utils@1100.0.1':
+    dependencies:
+      execa: safe-execa@0.3.0
 
   '@pnpm/npm-conf@2.2.2':
     dependencies:
@@ -2843,6 +5710,30 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@pnpm/npm-lifecycle@1100.0.0-1(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/byline': 1.0.0
+      '@pnpm/error': 1000.1.0
+      '@yarnpkg/fslib': 3.1.5
+      '@yarnpkg/shell': 4.0.0(typanion@3.14.0)
+      node-gyp: 11.5.0
+      uid-number: 0.0.6
+      which: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+      - typanion
+
+  '@pnpm/npm-package-arg@2.0.0':
+    dependencies:
+      hosted-git-info: 4.1.0
+      semver: 7.7.2
+      validate-npm-package-name: 4.0.0
+
+  '@pnpm/object.key-sorting@1100.0.0':
+    dependencies:
+      '@pnpm/util.lex-comparator': 3.0.2
+      sort-keys: 6.0.0
 
   '@pnpm/package-is-installable@9.0.2(@pnpm/logger@5.2.0)':
     dependencies:
@@ -2863,6 +5754,55 @@ snapshots:
   '@pnpm/parse-wanted-dependency@6.0.0':
     dependencies:
       validate-npm-package-name: 5.0.0
+
+  '@pnpm/patch-package@0.0.1':
+    dependencies:
+      '@yarnpkg/lockfile': 1.1.0
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      cross-spawn: 7.0.6
+      find-yarn-workspace-root: 2.0.0
+      fs-extra: 11.3.5
+      klaw-sync: 6.0.0
+      minimist: 1.2.8
+      open: 7.4.2
+      rimraf: 2.7.1
+      semver: 5.7.2
+      slash: 2.0.0
+      tmp: 0.0.33
+      yaml: 2.9.0
+
+  '@pnpm/patching.apply-patch@1100.0.0(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/patch-package': 0.0.1
+
+  '@pnpm/patching.config@1100.0.3(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/error': 1100.0.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/patching.types': 1100.0.0
+      semver: 7.7.2
+
+  '@pnpm/patching.types@1100.0.0': {}
+
+  '@pnpm/pkg-manifest.reader@1100.0.3':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/types': 1101.1.0
+      load-json-file: 7.0.1
+      normalize-package-data: 8.0.0
+
+  '@pnpm/pkg-manifest.utils@1100.1.2(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/deps.peer-range': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/types': 1101.1.0
+      semver: 7.7.2
 
   '@pnpm/pnpmfile@6.0.4(@pnpm/logger@5.2.0)':
     dependencies:
@@ -2911,19 +5851,255 @@ snapshots:
     dependencies:
       '@pnpm/types': 10.1.0
 
+  '@pnpm/resolving.default-resolver@1100.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/engine.runtime.bun-resolver': 1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/engine.runtime.deno-resolver': 1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/engine.runtime.node-resolver': 1101.0.7(@pnpm/logger@5.2.0)
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/resolving.git-resolver': 1100.0.6(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.local-resolver': 1101.0.0(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.npm-resolver': 1101.1.0(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/resolving.tarball-resolver': 1100.0.5
+      '@pnpm/types': 1101.1.0
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+      - '@pnpm/worker'
+
+  '@pnpm/resolving.git-resolver@1100.0.6(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/network.fetch': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      graceful-git: 5.0.0
+      hosted-git-info: '@pnpm/hosted-git-info@1.0.0'
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@pnpm/logger'
+
+  '@pnpm/resolving.jsr-specifier-parser@1100.0.0':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+
+  '@pnpm/resolving.local-resolver@1101.0.0(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+      '@pnpm/workspace.project-manifest-reader': 1100.0.4(@pnpm/logger@5.2.0)
+      normalize-path: 3.0.0
+
+  '@pnpm/resolving.npm-resolver@1101.1.0(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/config.pick-registry-for-package': 1100.0.3
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/core-loggers': 1100.0.2(@pnpm/logger@5.2.0)
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/resolving.jsr-specifier-parser': 1100.0.0
+      '@pnpm/resolving.registry.pkg-metadata-filter': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/resolving.registry.types': 1100.0.3
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.cafs': 1100.1.3
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      '@pnpm/workspace.range-resolver': 1100.0.1
+      '@pnpm/workspace.spec-parser': 1100.0.0
+      '@zkochan/retry': 0.2.0
+      encode-registry: 3.0.1
+      lru-cache: 11.3.6
+      normalize-path: 3.0.0
+      p-limit: 7.3.0
+      p-memoize: 8.0.0
+      parse-npm-tarball-url: 5.0.0
+      path-temp: 3.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      rename-overwrite: 7.0.1
+      semver: 7.7.2
+      semver-utils: 1.1.4
+      ssri: 13.0.1
+      version-selector-type: 3.0.0
+
+  '@pnpm/resolving.parse-wanted-dependency@1100.0.1':
+    dependencies:
+      validate-npm-package-name: 7.0.2
+
+  '@pnpm/resolving.registry.pkg-metadata-filter@1100.0.3(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/logger': 5.2.0
+      '@pnpm/resolving.registry.types': 1100.0.3
+      semver: 7.7.2
+
+  '@pnpm/resolving.registry.types@1100.0.3':
+    dependencies:
+      '@pnpm/types': 1101.1.0
+
+  '@pnpm/resolving.resolver-base@1100.1.3':
+    dependencies:
+      '@pnpm/types': 1101.1.0
+
+  '@pnpm/resolving.tarball-resolver@1100.0.5':
+    dependencies:
+      '@pnpm/fetching.types': 1100.0.1
+      '@pnpm/resolving.resolver-base': 1100.1.3
+
+  '@pnpm/semver-diff@2.0.0': {}
+
+  '@pnpm/slice-ansi@1.1.3':
+    dependencies:
+      grapheme-splitter: 1.0.4
+
   '@pnpm/store-controller-types@18.1.0':
     dependencies:
       '@pnpm/fetcher-base': 16.0.1
       '@pnpm/resolver-base': 12.0.1
       '@pnpm/types': 10.1.0
 
+  '@pnpm/store.cafs-types@1100.0.1': {}
+
+  '@pnpm/store.cafs@1100.1.3':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/types': 1101.1.0
+      '@zkochan/rimraf': 4.0.0
+      is-gzip: 2.0.0
+      is-subdir: 2.0.0
+      p-limit: 7.3.0
+      rename-overwrite: 7.0.1
+      semver: 7.7.2
+      strip-bom: 5.0.0
+
+  '@pnpm/store.connection-manager@1100.1.1(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)':
+    dependencies:
+      '@pnpm/cli.meta': 1100.0.3
+      '@pnpm/config.reader': 1101.3.0(@pnpm/logger@5.2.0)
+      '@pnpm/installing.client': 1100.0.14(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))(ts-toolbelt@9.6.0)(typanion@3.14.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.controller': 1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/store.path': 1100.0.1
+      dir-is-case-sensitive: 3.0.0
+    transitivePeerDependencies:
+      - '@pnpm/worker'
+      - supports-color
+      - ts-toolbelt
+      - typanion
+
+  '@pnpm/store.controller-types@1100.0.6':
+    dependencies:
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/types': 1101.1.0
+
+  '@pnpm/store.controller@1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))':
+    dependencies:
+      '@pnpm/crypto.hash': 1100.0.1
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/hooks.types': 1100.0.6
+      '@pnpm/installing.package-requester': 1101.0.5(@pnpm/logger@5.2.0)(@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21))
+      '@pnpm/logger': 5.2.0
+      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/store.cafs': 1100.1.3
+      '@pnpm/store.controller-types': 1100.0.6
+      '@pnpm/store.create-cafs-store': 1100.0.6(@pnpm/logger@5.2.0)
+      '@pnpm/store.index': 1100.1.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/worker': 1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)
+      '@zkochan/rimraf': 4.0.0
+      is-subdir: 2.0.0
+      pretty-bytes: 7.1.0
+      ramda: '@pnpm/ramda@0.28.1'
+      ssri: 13.0.1
+      symlink-dir: 10.0.1
+
+  '@pnpm/store.create-cafs-store@1100.0.6(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/building.pkg-requires-build': 1100.0.3
+      '@pnpm/fetching.fetcher-base': 1100.1.3
+      '@pnpm/fs.indexed-pkg-importer': 1100.0.6(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.cafs': 1100.1.3
+      '@pnpm/store.controller-types': 1100.0.6
+      memoize: 10.2.0
+      path-temp: 3.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/store.index@1100.1.0':
+    dependencies:
+      msgpackr: 1.11.8
+
+  '@pnpm/store.path@1100.0.1':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/error': 1100.0.0
+      '@zkochan/rimraf': 4.0.0
+      can-link: 3.0.0
+      path-absolute: 2.0.0
+      path-temp: 3.0.0
+      root-link-target: 4.0.0
+      touch: 3.1.1
+
+  '@pnpm/tabtab@0.5.4':
+    dependencies:
+      debug: 4.4.1
+      enquirer: 2.4.1
+      minimist: 1.2.8
+      untildify: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@pnpm/text.comments-parser@1100.0.0':
+    dependencies:
+      strip-comments-strings: 1.2.0
+
   '@pnpm/text.comments-parser@3.0.0':
     dependencies:
       strip-comments-strings: 1.2.0
 
+  '@pnpm/text.naming-cases@1100.0.1': {}
+
+  '@pnpm/text.tree-renderer@1100.0.0': {}
+
   '@pnpm/types@10.1.0': {}
 
+  '@pnpm/types@1101.1.0': {}
+
   '@pnpm/util.lex-comparator@3.0.0': {}
+
+  '@pnpm/util.lex-comparator@3.0.2': {}
+
+  '@pnpm/worker@1100.1.4(@pnpm/logger@5.2.0)(@types/node@22.15.21)':
+    dependencies:
+      '@pnpm/building.pkg-requires-build': 1100.0.3
+      '@pnpm/crypto.integrity': 1100.0.0
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/fs.hard-link-dir': 1100.0.1(@pnpm/logger@5.2.0)
+      '@pnpm/fs.symlink-dependency': 1100.0.3(@pnpm/logger@5.2.0)
+      '@pnpm/logger': 5.2.0
+      '@pnpm/store.cafs': 1100.1.3
+      '@pnpm/store.cafs-types': 1100.0.1
+      '@pnpm/store.create-cafs-store': 1100.0.6(@pnpm/logger@5.2.0)
+      '@pnpm/store.index': 1100.1.0
+      '@rushstack/worker-pool': 0.7.7(@types/node@22.15.21)
+      is-windows: 1.0.2
+      p-limit: 7.3.0
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@pnpm/workspace.find-packages@2.1.1(@pnpm/logger@5.2.0)':
     dependencies:
@@ -2934,11 +6110,49 @@ snapshots:
       '@pnpm/util.lex-comparator': 3.0.0
       '@pnpm/workspace.read-manifest': 2.0.1
 
+  '@pnpm/workspace.project-manifest-reader@1100.0.4(@pnpm/logger@5.2.0)':
+    dependencies:
+      '@pnpm/error': 1100.0.0
+      '@pnpm/fs.graceful-fs': 1100.1.0
+      '@pnpm/logger': 5.2.0
+      '@pnpm/pkg-manifest.utils': 1100.1.2(@pnpm/logger@5.2.0)
+      '@pnpm/text.comments-parser': 1100.0.0
+      '@pnpm/types': 1101.1.0
+      '@pnpm/workspace.project-manifest-writer': 1100.0.3
+      detect-indent: 7.0.2
+      fast-deep-equal: 3.1.3
+      is-windows: 1.0.2
+      json5: 2.2.3
+      parse-json: 8.3.0
+      read-yaml-file: 3.0.0
+      strip-bom: 5.0.0
+
+  '@pnpm/workspace.project-manifest-writer@1100.0.3':
+    dependencies:
+      '@pnpm/text.comments-parser': 1100.0.0
+      '@pnpm/types': 1101.1.0
+      json5: 2.2.3
+      write-file-atomic: 7.0.1
+      write-yaml-file: 6.0.0
+
+  '@pnpm/workspace.range-resolver@1100.0.1':
+    dependencies:
+      semver: 7.7.2
+
   '@pnpm/workspace.read-manifest@2.0.1':
     dependencies:
       '@pnpm/constants': 8.0.0
       '@pnpm/error': 6.0.1
       read-yaml-file: 2.1.0
+
+  '@pnpm/workspace.spec-parser@1100.0.0': {}
+
+  '@pnpm/workspace.workspace-manifest-reader@1100.0.3':
+    dependencies:
+      '@pnpm/constants': 1100.0.0
+      '@pnpm/error': 1100.0.0
+      '@pnpm/types': 1101.1.0
+      read-yaml-file: 3.0.0
 
   '@pnpm/write-project-manifest@6.0.1':
     dependencies:
@@ -2947,6 +6161,41 @@ snapshots:
       json5: 2.2.3
       write-file-atomic: 5.0.1
       write-yaml-file: 5.0.0
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
 
   '@rollup/rollup-android-arm-eabi@4.41.0':
     optional: true
@@ -3008,13 +6257,38 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.41.0':
     optional: true
 
+  '@rushstack/worker-pool@0.7.7(@types/node@22.15.21)':
+    optionalDependencies:
+      '@types/node': 22.15.21
+
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
+
   '@tootallnate/once@1.1.2': {}
 
+  '@types/bintrees@1.0.6': {}
+
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 22.15.21
+      '@types/responselike': 1.0.3
+
+  '@types/emscripten@1.41.5': {}
+
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.7': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/fs-extra@9.0.13':
     dependencies:
@@ -3025,24 +6299,44 @@ snapshots:
       '@types/minimatch': 5.1.2
       '@types/node': 22.15.21
 
+  '@types/http-cache-semantics@4.2.0': {}
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 22.15.21
 
   '@types/minimatch@3.0.5': {}
 
   '@types/minimatch@5.1.2': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.15.21':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 22.15.21
 
   '@types/rimraf@3.0.2':
     dependencies:
       '@types/glob': 8.1.0
       '@types/node': 22.15.21
 
+  '@types/semver@6.2.7': {}
+
+  '@types/semver@7.7.1': {}
+
   '@types/ssri@7.1.5':
     dependencies:
       '@types/node': 22.15.21
+
+  '@types/treeify@1.0.3': {}
 
   '@vitest/expect@3.1.4':
     dependencies:
@@ -3051,13 +6345,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.15.21))':
+  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.15.21)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.21)
+      vite: 6.3.5(@types/node@22.15.21)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -3084,21 +6378,170 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
+  '@yarnpkg/core@4.5.0(typanion@3.14.0)':
+    dependencies:
+      '@arcanis/slice-ansi': 1.1.1
+      '@types/semver': 7.7.1
+      '@types/treeify': 1.0.3
+      '@yarnpkg/fslib': 3.1.5
+      '@yarnpkg/libzip': 3.2.2(@yarnpkg/fslib@3.1.5)
+      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/shell': 4.1.3(typanion@3.14.0)
+      camelcase: 5.3.1
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      cross-spawn: 7.0.6
+      diff: 5.2.2
+      dotenv: 16.6.1
+      es-toolkit: 1.46.1
+      fast-glob: 3.3.3
+      got: 11.8.6
+      hpagent: 1.2.0
+      micromatch: 4.0.8
+      p-limit: 2.3.0
+      semver: 7.7.2
+      strip-ansi: 6.0.1
+      tar: 6.2.1
+      tinylogic: 2.0.0
+      treeify: 1.1.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - typanion
+
+  '@yarnpkg/core@4.7.0(typanion@3.14.0)':
+    dependencies:
+      '@arcanis/slice-ansi': 1.1.1
+      '@types/semver': 7.7.1
+      '@types/treeify': 1.0.3
+      '@yarnpkg/fslib': 3.1.5
+      '@yarnpkg/libzip': 3.2.2(@yarnpkg/fslib@3.1.5)
+      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/shell': 4.1.3(typanion@3.14.0)
+      camelcase: 5.3.1
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      cross-spawn: 7.0.6
+      diff: 5.2.2
+      dotenv: 16.6.1
+      es-toolkit: 1.46.1
+      fast-glob: 3.3.3
+      got: 11.8.6
+      hpagent: 1.2.0
+      micromatch: 4.0.8
+      p-limit: 2.3.0
+      semver: 7.7.2
+      strip-ansi: 6.0.1
+      tar: 7.5.15
+      tinylogic: 2.0.0
+      treeify: 1.1.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - typanion
+
+  '@yarnpkg/extensions@2.0.6(@yarnpkg/core@4.7.0(typanion@3.14.0))':
+    dependencies:
+      '@yarnpkg/core': 4.7.0(typanion@3.14.0)
+
+  '@yarnpkg/fslib@3.1.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@yarnpkg/libzip@3.2.2(@yarnpkg/fslib@3.1.5)':
+    dependencies:
+      '@types/emscripten': 1.41.5
+      '@yarnpkg/fslib': 3.1.5
+      tslib: 2.8.1
+
+  '@yarnpkg/lockfile@1.1.0': {}
+
+  '@yarnpkg/nm@4.0.7(typanion@3.14.0)':
+    dependencies:
+      '@yarnpkg/core': 4.7.0(typanion@3.14.0)
+      '@yarnpkg/fslib': 3.1.5
+      '@yarnpkg/pnp': 4.1.5
+    transitivePeerDependencies:
+      - typanion
+
+  '@yarnpkg/parsers@3.0.3':
+    dependencies:
+      js-yaml: 3.14.2
+      tslib: 2.8.1
+
+  '@yarnpkg/pnp@4.1.5':
+    dependencies:
+      '@types/node': 18.19.130
+      '@yarnpkg/fslib': 3.1.5
+
+  '@yarnpkg/shell@4.0.0(typanion@3.14.0)':
+    dependencies:
+      '@yarnpkg/fslib': 3.1.5
+      '@yarnpkg/parsers': 3.0.3
+      chalk: 3.0.0
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      cross-spawn: 7.0.3
+      fast-glob: 3.3.3
+      micromatch: 4.0.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - typanion
+
+  '@yarnpkg/shell@4.1.3(typanion@3.14.0)':
+    dependencies:
+      '@yarnpkg/fslib': 3.1.5
+      '@yarnpkg/parsers': 3.0.3
+      chalk: 4.1.2
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      cross-spawn: 7.0.6
+      fast-glob: 3.3.3
+      micromatch: 4.0.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - typanion
+
+  '@zkochan/cmd-shim@9.0.3':
+    dependencies:
+      cmd-extension: 1.0.2
+      graceful-fs: 4.2.11
+
+  '@zkochan/js-yaml@0.0.11':
+    dependencies:
+      argparse: 2.0.1
+
+  '@zkochan/retry@0.2.0': {}
+
+  '@zkochan/rimraf@4.0.0': {}
+
+  '@zkochan/table@2.0.1':
+    dependencies:
+      ajv: 8.20.0
+      lodash.truncate: 4.4.2
+      slice-ansi: '@pnpm/slice-ansi@1.1.3'
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   '@zkochan/which@2.0.3':
     dependencies:
       isexe: 2.0.0
 
-  acorn-jsx@5.3.2(acorn@8.14.1):
-    dependencies:
-      acorn: 8.14.1
+  abbrev@3.0.1: {}
 
-  acorn@8.14.1: {}
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  adm-zip@0.5.17: {}
 
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.4: {}
 
   agentkeepalive@4.6.0:
     dependencies:
@@ -3109,16 +6552,25 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv@6.12.6:
+  ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-align@3.0.1:
     dependencies:
       string-width: 4.2.3
+
+  ansi-colors@4.1.3: {}
 
   ansi-diff@1.2.0:
     dependencies:
@@ -3145,6 +6597,10 @@ snapshots:
 
   archy@1.0.0: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   as-table@1.0.55:
@@ -3163,9 +6619,15 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   before-after-hook@3.0.2: {}
 
   better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
+
+  better-path-resolve@2.0.0:
     dependencies:
       is-windows: 1.0.2
 
@@ -3177,6 +6639,16 @@ snapshots:
       read-cmd-shim: 3.0.1
       rimraf: 3.0.2
       write-file-atomic: 4.0.2
+
+  bin-links@6.0.0:
+    dependencies:
+      cmd-shim: 8.0.0
+      npm-normalize-package-bin: 5.0.0
+      proc-log: 6.1.0
+      read-cmd-shim: 6.0.0
+      write-file-atomic: 7.0.1
+
+  bintrees@1.0.2: {}
 
   bole@5.0.19:
     dependencies:
@@ -3202,6 +6674,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -3236,7 +6712,39 @@ snapshots:
     transitivePeerDependencies:
       - bluebird
 
-  callsites@3.1.0: {}
+  cacache@19.0.1:
+    dependencies:
+      '@npmcli/fs': 4.0.0
+      fs-minipass: 3.0.3
+      glob: 10.4.5
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.4
+      ssri: 12.0.0
+      tar: 7.5.15
+      unique-filename: 4.0.0
+
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
+
+  camelcase-keys@10.0.2:
+    dependencies:
+      camelcase: 9.0.0
+      map-obj: 6.0.0
+      quick-lru: 7.3.0
+      type-fest: 5.6.0
 
   camelcase-keys@6.2.2:
     dependencies:
@@ -3248,9 +6756,17 @@ snapshots:
 
   camelcase@6.3.0: {}
 
+  camelcase@9.0.0: {}
+
+  can-link@3.0.0: {}
+
   can-write-to-dir@1.1.1:
     dependencies:
       path-temp: 2.1.0
+
+  can-write-to-dir@2.0.0:
+    dependencies:
+      path-temp: 3.0.0
 
   chai@5.2.0:
     dependencies:
@@ -3260,18 +6776,29 @@ snapshots:
       loupe: 3.1.3
       pathval: 2.0.0
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chalk@5.4.1: {}
+  chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
 
   check-error@2.1.1: {}
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
+
+  ci-info@3.9.0: {}
+
+  ci-info@4.4.0: {}
 
   clean-stack@2.2.0: {}
 
@@ -3296,6 +6823,10 @@ snapshots:
       slice-ansi: 3.0.0
       string-width: 4.2.3
 
+  clipanion@4.0.0-rc.4(typanion@3.14.0):
+    dependencies:
+      typanion: 3.14.0
+
   cliui@7.0.4:
     dependencies:
       string-width: 4.2.3
@@ -3308,11 +6839,21 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
+
   clone@1.0.4: {}
+
+  cmd-extension@1.0.2: {}
+
+  cmd-extension@2.0.0: {}
 
   cmd-shim@5.0.0:
     dependencies:
       mkdirp-infer-owner: 2.0.0
+
+  cmd-shim@8.0.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3321,6 +6862,8 @@ snapshots:
   color-name@1.1.4: {}
 
   commander@14.0.0: {}
+
+  comver-to-semver@2.0.0: {}
 
   concat-map@0.0.1: {}
 
@@ -3339,6 +6882,12 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
+  cross-spawn@7.0.3:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3347,11 +6896,19 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  crypto-random-string@4.0.0:
+    dependencies:
+      type-fest: 1.4.0
+
   data-uri-to-buffer@2.0.2: {}
 
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
 
   deep-eql@5.0.2: {}
 
@@ -3365,7 +6922,19 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  defer-to-connect@2.0.1: {}
+
+  detect-indent@7.0.2: {}
+
   detect-libc@2.0.4: {}
+
+  diff@5.2.2: {}
+
+  dir-is-case-sensitive@3.0.0:
+    dependencies:
+      path-temp: 3.0.0
+
+  dotenv@16.6.1: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -3375,12 +6944,27 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encode-registry@3.0.1:
+    dependencies:
+      mem: 8.1.1
+
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
     optional: true
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
+
   ensure-posix-path@1.1.1: {}
+
+  env-paths@2.2.1: {}
 
   err-code@2.0.3: {}
 
@@ -3389,6 +6973,8 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-module-lexer@1.7.0: {}
+
+  es-toolkit@1.46.1: {}
 
   esbuild@0.25.4:
     optionalDependencies:
@@ -3422,39 +7008,39 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-scope@8.3.0:
+  escape-string-regexp@5.0.0: {}
+
+  eslint-scope@9.1.2:
     dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
 
-  eslint-visitor-keys@4.2.0: {}
+  eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.27.0:
+  eslint@10.3.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@9.27.0)
-      '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.20.0
-      '@eslint/config-helpers': 0.2.2
-      '@eslint/core': 0.14.0
-      '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.27.0
-      '@eslint/plugin-kit': 0.3.1
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.5.5
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.7
-      '@types/json-schema': 7.0.15
-      ajv: 6.12.6
-      chalk: 4.1.2
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.1
       escape-string-regexp: 4.0.0
-      eslint-scope: 8.3.0
-      eslint-visitor-keys: 4.2.0
-      espree: 10.3.0
-      esquery: 1.6.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 8.0.0
@@ -3464,20 +7050,21 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     transitivePeerDependencies:
       - supports-color
 
-  espree@10.3.0:
+  espree@11.2.0:
     dependencies:
-      acorn: 8.14.1
-      acorn-jsx: 5.3.2(acorn@8.14.1)
-      eslint-visitor-keys: 4.2.0
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
 
-  esquery@1.6.0:
+  esprima@4.0.1: {}
+
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -3489,9 +7076,11 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   execa@5.1.1:
     dependencies:
@@ -3505,7 +7094,7 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@9.5.3:
+  execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
       cross-spawn: 7.0.6
@@ -3521,6 +7110,8 @@ snapshots:
       yoctocolors: 2.1.1
 
   expect-type@1.2.1: {}
+
+  exponential-backoff@3.1.3: {}
 
   fast-content-type-parse@2.0.1: {}
 
@@ -3540,13 +7131,17 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-string-compare@3.0.0: {}
+
+  fast-uri@3.1.2: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.4.4(picomatch@4.0.2):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.2
+      picomatch: 4.0.4
 
   figures@6.1.0:
     dependencies:
@@ -3560,10 +7155,25 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up-simple@1.0.1: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  find-yarn-workspace-root2@1.2.53(ts-toolbelt@9.6.0):
+    dependencies:
+      micromatch: 4.0.8
+      pkg-dir: 5.0.0
+      tslib: 2.8.1
+      upath2: 3.1.23(ts-toolbelt@9.6.0)
+    transitivePeerDependencies:
+      - ts-toolbelt
+
+  find-yarn-workspace-root@2.0.0:
+    dependencies:
+      micromatch: 4.0.8
 
   fixturify-project@7.1.3:
     dependencies:
@@ -3606,11 +7216,17 @@ snapshots:
 
   fs-extra@10.1.0:
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
 
-  fs-extra@11.3.0:
+  fs-extra@11.3.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -3619,13 +7235,17 @@ snapshots:
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
 
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
+
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.2
 
   fs.realpath@1.0.0: {}
 
@@ -3634,10 +7254,16 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-npm-tarball-url@2.1.0: {}
+
   get-source@2.0.12:
     dependencies:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
 
   get-stream@6.0.1: {}
 
@@ -3695,13 +7321,38 @@ snapshots:
       minimatch: 5.1.6
       once: 1.4.0
 
-  globals@14.0.0: {}
-
   globals@16.1.0: {}
+
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
 
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
+
+  graceful-git@5.0.0:
+    dependencies:
+      retry: 0.13.1
+      safe-execa: 0.3.0
+
+  graph-cycles@3.0.0:
+    dependencies:
+      fast-string-compare: 3.0.0
+      rotated-array-set: 3.0.0
+      short-tree: 3.0.0
+
+  grapheme-splitter@1.0.4: {}
 
   has-flag@4.0.0: {}
 
@@ -3715,6 +7366,12 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.3.6
+
+  hpagent@1.2.0: {}
+
   http-cache-semantics@4.2.0: {}
 
   http-proxy-agent@4.0.1:
@@ -3725,9 +7382,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
@@ -3749,16 +7425,17 @@ snapshots:
     dependencies:
       minimatch: 5.1.6
 
-  ignore@5.3.2: {}
-
-  import-fresh@3.3.1:
+  ignore-walk@8.0.0:
     dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
+      minimatch: 10.2.5
+
+  ignore@5.3.2: {}
 
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  index-to-position@1.2.0: {}
 
   individual@3.0.0: {}
 
@@ -3777,12 +7454,16 @@ snapshots:
 
   ini@5.0.0: {}
 
+  ini@6.0.0: {}
+
   ip-address@9.0.5:
     dependencies:
       jsbn: 1.1.0
       sprintf-js: 1.1.3
 
   is-arrayish@0.2.1: {}
+
+  is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -3791,6 +7472,13 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-gzip@2.0.0: {}
+
+  is-inner-link@5.0.0:
+    dependencies:
+      is-subdir: 2.0.0
+      resolve-link-target: 3.0.0
 
   is-lambda@1.0.1: {}
 
@@ -3802,15 +7490,25 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  is-stream@3.0.0: {}
+
   is-stream@4.0.1: {}
 
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
 
+  is-subdir@2.0.0:
+    dependencies:
+      better-path-resolve: 2.0.0
+
   is-unicode-supported@2.1.0: {}
 
   is-windows@1.0.2: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   isexe@2.0.0: {}
 
@@ -3828,7 +7526,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.0:
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
@@ -3842,6 +7545,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
@@ -3852,11 +7557,15 @@ snapshots:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  klaw-sync@6.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
 
   ky@1.8.1: {}
 
@@ -3873,10 +7582,18 @@ snapshots:
 
   load-json-file@6.2.0:
     dependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       parse-json: 5.2.0
       strip-bom: 4.0.0
       type-fest: 0.6.0
+
+  load-json-file@7.0.1: {}
+
+  load-yaml-file@1.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 4.1.1
+      strip-bom: 5.0.0
 
   locate-path@6.0.0:
     dependencies:
@@ -3884,13 +7601,21 @@ snapshots:
 
   lodash.clonedeep@4.5.0: {}
 
-  lodash.merge@4.6.2: {}
+  lodash.kebabcase@4.1.1: {}
+
+  lodash.throttle@4.1.1: {}
+
+  lodash.truncate@4.4.2: {}
 
   lodash@4.17.21: {}
 
   loupe@3.1.3: {}
 
+  lowercase-keys@2.0.0: {}
+
   lru-cache@10.4.3: {}
+
+  lru-cache@11.3.6: {}
 
   lru-cache@6.0.0:
     dependencies:
@@ -3899,6 +7624,26 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  make-empty-dir@4.0.0:
+    dependencies:
+      '@zkochan/rimraf': 4.0.0
+
+  make-fetch-happen@14.0.3:
+    dependencies:
+      '@npmcli/agent': 3.0.0
+      cacache: 19.0.1
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.2
+      minipass-fetch: 4.0.1
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 5.0.0
+      promise-retry: 2.0.1
+      ssri: 12.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   make-fetch-happen@9.1.0:
     dependencies:
@@ -3928,6 +7673,8 @@ snapshots:
 
   map-obj@4.3.0: {}
 
+  map-obj@6.0.0: {}
+
   matcher-collection@2.0.1:
     dependencies:
       '@types/minimatch': 3.0.5
@@ -3937,6 +7684,10 @@ snapshots:
     dependencies:
       map-age-cleaner: 0.1.3
       mimic-fn: 3.1.0
+
+  memoize@10.2.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   merge-stream@2.0.0: {}
 
@@ -3950,6 +7701,16 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-fn@3.1.0: {}
+
+  mimic-function@5.0.1: {}
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@3.1.2:
     dependencies:
@@ -3969,11 +7730,23 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.2
+
   minipass-fetch@1.4.1:
     dependencies:
       minipass: 3.3.6
       minipass-sized: 1.0.3
       minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+
+  minipass-fetch@4.0.1:
+    dependencies:
+      minipass: 7.1.2
+      minipass-sized: 1.0.3
+      minizlib: 3.1.0
     optionalDependencies:
       encoding: 0.1.13
 
@@ -4002,6 +7775,10 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.2
+
   mkdirp-infer-owner@2.0.0:
     dependencies:
       chownr: 2.0.0
@@ -4011,6 +7788,22 @@ snapshots:
   mkdirp@1.0.4: {}
 
   ms@2.1.3: {}
+
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.8:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
 
   mz@2.7.0:
     dependencies:
@@ -4032,9 +7825,47 @@ snapshots:
 
   negotiator@0.6.4: {}
 
+  negotiator@1.0.0: {}
+
+  next-path@1.0.0: {}
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.0.4
+    optional: true
+
+  node-gyp@11.5.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 14.0.3
+      nopt: 8.1.0
+      proc-log: 5.0.0
+      semver: 7.7.2
+      tar: 7.5.15
+      tinyglobby: 0.2.16
+      which: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
+
+  normalize-package-data@8.0.0:
+    dependencies:
+      hosted-git-info: 9.0.3
+      semver: 7.7.2
+      validate-npm-package-license: 3.0.4
+
   normalize-path@3.0.0: {}
 
   normalize-registry-url@2.0.0: {}
+
+  normalize-registry-url@2.0.1: {}
+
+  normalize-url@6.1.0: {}
 
   npm-bundled@2.0.1:
     dependencies:
@@ -4048,12 +7879,19 @@ snapshots:
 
   npm-normalize-package-bin@4.0.0: {}
 
+  npm-normalize-package-bin@5.0.0: {}
+
   npm-package-arg@12.0.2:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
       semver: 7.7.2
       validate-npm-package-name: 6.0.0
+
+  npm-packlist@10.0.4:
+    dependencies:
+      ignore-walk: 8.0.0
+      proc-log: 6.1.0
 
   npm-packlist@5.1.3:
     dependencies:
@@ -4080,6 +7918,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -4087,6 +7927,11 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  open@7.4.2:
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -4099,19 +7944,41 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
+  p-cancelable@2.1.1: {}
+
   p-defer@1.0.0: {}
+
+  p-defer@4.0.1: {}
+
+  p-every@2.0.0:
+    dependencies:
+      p-map: 2.1.0
 
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
 
+  p-filter@4.1.0:
+    dependencies:
+      p-map: 7.0.4
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@7.3.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-map-values@0.1.0: {}
 
   p-map@2.1.0: {}
 
@@ -4123,6 +7990,24 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
+  p-map@7.0.4: {}
+
+  p-memoize@8.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+      type-fest: 4.41.0
+
+  p-queue@9.2.0:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
+  p-reflect@3.1.0: {}
+
+  p-timeout@7.0.1: {}
+
+  p-try@2.2.0: {}
+
   package-json-from-dist@1.0.1: {}
 
   package-json@10.0.1:
@@ -4131,10 +8016,6 @@ snapshots:
       registry-auth-token: 5.1.0
       registry-url: 6.0.1
       semver: 7.7.2
-
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
 
   parse-github-repo-url@1.4.1: {}
 
@@ -4145,9 +8026,19 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
+
   parse-ms@2.1.0: {}
 
   parse-ms@4.0.0: {}
+
+  parse-npm-tarball-url@5.0.0:
+    dependencies:
+      semver: 7.7.2
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
@@ -4159,9 +8050,17 @@ snapshots:
 
   path-absolute@1.0.1: {}
 
+  path-absolute@2.0.0: {}
+
   path-exists@4.0.0: {}
 
+  path-exists@5.0.0: {}
+
   path-is-absolute@1.0.1: {}
+
+  path-is-network-drive@1.0.24:
+    dependencies:
+      tslib: 2.8.1
 
   path-key@3.1.1: {}
 
@@ -4180,9 +8079,17 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  path-strip-sep@1.0.21:
+    dependencies:
+      tslib: 2.8.1
+
   path-temp@2.1.0:
     dependencies:
       unique-string: 2.0.0
+
+  path-temp@3.0.0:
+    dependencies:
+      unique-string: 3.0.0
 
   pathe@2.0.3: {}
 
@@ -4192,7 +8099,11 @@ snapshots:
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.2: {}
+  picomatch@4.0.4: {}
+
+  pkg-dir@5.0.0:
+    dependencies:
+      find-up: 5.0.0
 
   pkg-entry-points@1.1.1: {}
 
@@ -4202,11 +8113,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  preferred-pm@5.0.0(ts-toolbelt@9.6.0):
+    dependencies:
+      find-up-simple: 1.0.1
+      find-yarn-workspace-root2: 1.2.53(ts-toolbelt@9.6.0)
+      which-pm: 4.0.0
+    transitivePeerDependencies:
+      - ts-toolbelt
+
   prelude-ls@1.2.1: {}
 
   prettier@3.5.3: {}
 
   pretty-bytes@5.6.0: {}
+
+  pretty-bytes@7.1.0: {}
 
   pretty-ms@7.0.1:
     dependencies:
@@ -4220,6 +8141,8 @@ snapshots:
 
   proc-log@5.0.0: {}
 
+  proc-log@6.1.0: {}
+
   progress@2.0.3: {}
 
   promise-inflight@1.0.1: {}
@@ -4229,13 +8152,26 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
+  promise-share@2.0.0:
+    dependencies:
+      p-reflect: 3.1.0
+
   proto-list@1.2.4: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
   quick-lru@4.0.1: {}
+
+  quick-lru@5.1.1: {}
+
+  quick-lru@7.3.0: {}
 
   rc@1.2.8:
     dependencies:
@@ -4246,15 +8182,27 @@ snapshots:
 
   read-cmd-shim@3.0.1: {}
 
+  read-cmd-shim@6.0.0: {}
+
   read-ini-file@4.0.0:
     dependencies:
       ini: 3.0.1
       strip-bom: 4.0.0
 
+  read-ini-file@5.0.0:
+    dependencies:
+      ini: 6.0.0
+      strip-bom: 5.0.0
+
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       strip-bom: 4.0.0
+
+  read-yaml-file@3.0.0:
+    dependencies:
+      js-yaml: 4.1.1
+      strip-bom: 5.0.0
 
   readable-stream@3.6.2:
     dependencies:
@@ -4263,6 +8211,8 @@ snapshots:
       util-deprecate: 1.0.2
 
   realpath-missing@1.1.0: {}
+
+  realpath-missing@2.0.0: {}
 
   registry-auth-token@5.1.0:
     dependencies:
@@ -4278,12 +8228,12 @@ snapshots:
       '@npmcli/package-json': 6.1.1
       '@octokit/rest': 21.1.1
       assert-never: 1.4.0
-      chalk: 5.4.1
+      chalk: 5.6.2
       cli-highlight: 2.1.11
-      execa: 9.5.3
-      fs-extra: 11.3.0
+      execa: 9.6.1
+      fs-extra: 11.3.5
       github-changelog: 2.1.4
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       latest-version: 9.0.0
       parse-github-repo-url: 1.4.1
       semver: 7.7.2
@@ -4292,19 +8242,42 @@ snapshots:
       - bluebird
       - supports-color
 
+  rename-overwrite@7.0.1:
+    dependencies:
+      '@zkochan/rimraf': 4.0.0
+      fs-extra: 11.3.4
+
+  render-help@2.0.0:
+    dependencies:
+      table: 6.9.0
+
   require-directory@2.1.1: {}
 
-  resolve-from@4.0.0: {}
+  require-from-string@2.0.2: {}
+
+  resolve-alpn@1.2.1: {}
+
+  resolve-link-target@3.0.0: {}
 
   resolve-package-path@4.0.3:
     dependencies:
       path-root: 0.1.1
 
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
+
   retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
   rfc4648@1.5.4: {}
+
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
 
   rimraf@3.0.2:
     dependencies:
@@ -4336,6 +8309,18 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.41.0
       fsevents: 2.3.3
 
+  root-link-target@4.0.0:
+    dependencies:
+      can-link: 3.0.0
+      next-path: 1.0.0
+      path-temp: 3.0.0
+
+  rotated-array-set@3.0.0: {}
+
+  run-groups@5.0.0:
+    dependencies:
+      p-limit: 7.3.0
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4352,8 +8337,33 @@ snapshots:
       execa: 5.1.1
       path-name: 1.0.0
 
+  safe-execa@0.3.0:
+    dependencies:
+      '@zkochan/which': 2.0.3
+      execa: 9.6.1
+      path-name: 1.0.0
+
+  safe-promise-defer@2.0.0:
+    dependencies:
+      promise-share: 2.0.0
+
   safer-buffer@2.1.2:
     optional: true
+
+  sanitize-filename@1.6.4:
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
+
+  semver-range-intersect@0.3.1:
+    dependencies:
+      '@types/semver': 6.2.7
+      semver: 6.3.1
+
+  semver-utils@1.1.4: {}
+
+  semver@5.7.2: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.2: {}
 
@@ -4365,13 +8375,28 @@ snapshots:
 
   shell-quote@1.8.2: {}
 
+  shlex@3.0.0: {}
+
+  short-tree@3.0.0:
+    dependencies:
+      '@types/bintrees': 1.0.6
+      bintrees: 1.0.2
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
+  slash@2.0.0: {}
+
   slice-ansi@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
+  slice-ansi@4.0.0:
     dependencies:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
@@ -4387,6 +8412,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+      socks: 2.8.4
+    transitivePeerDependencies:
+      - supports-color
+
   socks@2.8.4:
     dependencies:
       ip-address: 9.0.5
@@ -4395,6 +8428,10 @@ snapshots:
   sort-keys@4.2.0:
     dependencies:
       is-plain-obj: 2.1.0
+
+  sort-keys@6.0.0:
+    dependencies:
+      is-plain-obj: 4.1.0
 
   source-map-js@1.2.1: {}
 
@@ -4418,7 +8455,17 @@ snapshots:
     dependencies:
       readable-stream: 3.6.2
 
+  sprintf-js@1.0.3: {}
+
   sprintf-js@1.1.3: {}
+
+  ssri@12.0.0:
+    dependencies:
+      minipass: 7.1.2
+
+  ssri@13.0.1:
+    dependencies:
+      minipass: 7.1.2
 
   ssri@8.0.1:
     dependencies:
@@ -4464,6 +8511,8 @@ snapshots:
 
   strip-bom@4.0.0: {}
 
+  strip-bom@5.0.0: {}
+
   strip-comments-strings@1.2.0: {}
 
   strip-final-newline@2.0.0: {}
@@ -4471,8 +8520,6 @@ snapshots:
   strip-final-newline@4.0.0: {}
 
   strip-json-comments@2.0.1: {}
-
-  strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -4482,6 +8529,21 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symlink-dir@10.0.1:
+    dependencies:
+      better-path-resolve: 2.0.0
+      rename-overwrite: 7.0.1
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.20.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  tagged-tag@1.0.0: {}
+
   tar@6.2.1:
     dependencies:
       chownr: 2.0.0
@@ -4490,6 +8552,29 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  temp-dir@2.0.0: {}
+
+  temporal-polyfill@0.3.2:
+    dependencies:
+      temporal-spec: 0.3.1
+
+  temporal-spec@0.3.1: {}
+
+  tempy@3.0.0:
+    dependencies:
+      is-stream: 3.0.0
+      temp-dir: 2.0.0
+      type-fest: 2.19.0
+      unique-string: 3.0.0
 
   thenify-all@1.6.0:
     dependencies:
@@ -4507,10 +8592,12 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyglobby@0.2.13:
+  tinyglobby@0.2.16:
     dependencies:
-      fdir: 6.4.4(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinylogic@2.0.0: {}
 
   tinypool@1.0.2: {}
 
@@ -4526,9 +8613,28 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  touch@3.1.1: {}
+
   tree-kill@1.2.2: {}
 
+  treeify@1.1.0: {}
+
+  truncate-utf8-bytes@1.0.2:
+    dependencies:
+      utf8-byte-length: 1.0.5
+
+  ts-toolbelt@9.6.0: {}
+
+  ts-type@3.0.13(ts-toolbelt@9.6.0):
+    dependencies:
+      '@types/node': 22.15.21
+      ts-toolbelt: 9.6.0
+      tslib: 2.8.1
+      typedarray-dts: 1.0.0
+
   tslib@2.8.1: {}
+
+  typanion@3.14.0: {}
 
   type-check@0.4.0:
     dependencies:
@@ -4538,11 +8644,27 @@ snapshots:
 
   type-fest@0.6.0: {}
 
+  type-fest@1.4.0: {}
+
+  type-fest@2.19.0: {}
+
   type-fest@4.41.0: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  typedarray-dts@1.0.0: {}
 
   typescript-memoize@1.1.1: {}
 
+  uid-number@0.0.6: {}
+
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
+
+  undici@7.25.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -4550,7 +8672,15 @@ snapshots:
     dependencies:
       unique-slug: 2.0.2
 
+  unique-filename@4.0.0:
+    dependencies:
+      unique-slug: 5.0.0
+
   unique-slug@2.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+
+  unique-slug@5.0.0:
     dependencies:
       imurmurhash: 0.1.4
 
@@ -4558,13 +8688,31 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
+  unique-string@3.0.0:
+    dependencies:
+      crypto-random-string: 4.0.0
+
   universal-user-agent@7.0.3: {}
 
   universalify@2.0.1: {}
 
+  untildify@4.0.0: {}
+
+  upath2@3.1.23(ts-toolbelt@9.6.0):
+    dependencies:
+      '@lazy-node/types-path': 1.0.3(ts-toolbelt@9.6.0)
+      '@types/node': 22.15.21
+      path-is-network-drive: 1.0.24
+      path-strip-sep: 1.0.21
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - ts-toolbelt
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
 
@@ -4573,19 +8721,29 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  validate-npm-package-name@4.0.0:
+    dependencies:
+      builtins: 5.1.0
+
   validate-npm-package-name@5.0.0:
     dependencies:
       builtins: 5.1.0
 
   validate-npm-package-name@6.0.0: {}
 
-  vite-node@3.1.4(@types/node@22.15.21):
+  validate-npm-package-name@7.0.2: {}
+
+  version-selector-type@3.0.0:
+    dependencies:
+      semver: 7.7.2
+
+  vite-node@3.1.4(@types/node@22.15.21)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.21)
+      vite: 6.3.5(@types/node@22.15.21)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4600,22 +8758,23 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@22.15.21):
+  vite@6.3.5(@types/node@22.15.21)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.4
-      fdir: 6.4.4(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.3
       rollup: 4.41.0
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.15.21
       fsevents: 2.3.3
+      yaml: 2.9.0
 
-  vitest@3.1.4(@types/node@22.15.21):
+  vitest@3.1.4(@types/node@22.15.21)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.15.21))
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.15.21)(yaml@2.9.0))
       '@vitest/pretty-format': 3.1.4
       '@vitest/runner': 3.1.4
       '@vitest/snapshot': 3.1.4
@@ -4629,11 +8788,11 @@ snapshots:
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.13
+      tinyglobby: 0.2.16
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.15.21)
-      vite-node: 3.1.4(@types/node@22.15.21)
+      vite: 6.3.5(@types/node@22.15.21)(yaml@2.9.0)
+      vite-node: 3.1.4(@types/node@22.15.21)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.21
@@ -4661,6 +8820,10 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  which-pm@4.0.0:
+    dependencies:
+      load-yaml-file: 1.0.0
 
   which@2.0.2:
     dependencies:
@@ -4709,14 +8872,27 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
+
   write-yaml-file@5.0.0:
     dependencies:
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       write-file-atomic: 5.0.1
+
+  write-yaml-file@6.0.0:
+    dependencies:
+      js-yaml: 4.1.1
+      write-file-atomic: 7.0.1
 
   y18n@5.0.8: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 
@@ -4743,5 +8919,7 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.1: {}

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,7 +1,6 @@
 import { beforeEach, it, describe, expect, vi } from 'vitest';
 import { join } from 'node:path';
 import { readFile } from 'node:fs/promises';
-import semver from 'semver';
 import { Project } from 'fixturify-project';
 
 const mockConsoleError = vi.spyOn(console, 'error');
@@ -14,20 +13,23 @@ let project;
 import main from '../index.js';
 
 // this is to prevent the tests from being flakey and also stops it hitting the network
-vi.mock('latest-version', () => {
+vi.mock('@pnpm/deps.inspection.commands', () => {
   return {
-    default(pkg, { version }) {
-      // latest is always all sevens
-      if (version === 'latest') {
-        return '7.7.7';
-      }
+    view: {
+      handler: (_config, [, command]) => {
+        if (command === 'time') {
+          return JSON.stringify({
+            '5.2.0': '2025-10-30T21:30:31.370Z',
+          });
+        }
 
-      if (version === 'beta') {
-        return '8.0.0-beta.5';
-      }
-
-      // otherwise increment a minor
-      return semver.inc(semver.valid(semver.coerce(version)), 'minor');
+        if (command === 'dist-tags') {
+          return JSON.stringify({
+            beta: '8.0.0-beta.5',
+            latest: '7.7.7',
+          });
+        }
+      },
     },
   };
 });

--- a/tests/latest-version.test.js
+++ b/tests/latest-version.test.js
@@ -1,0 +1,72 @@
+import { expect } from 'vitest';
+import { getLatestVersion } from '../lib/latest-version';
+
+import { describe, it, vi } from 'vitest';
+import { afterEach } from 'vitest';
+import { beforeEach } from 'vitest';
+
+// this is to prevent the tests from being flakey and also stops it hitting the network
+vi.mock('@pnpm/deps.inspection.commands', () => {
+  return {
+    view: {
+      handler: (_config, [, command]) => {
+        if (command === 'time') {
+          return JSON.stringify({
+            '6.8.1': '2025-10-30T21:30:31.370Z',
+            '6.8.2': '2025-11-18T03:17:47.374Z',
+            '6.8.3': '2026-02-04T16:40:48.317Z',
+            '6.11.0': '2026-02-17T19:17:36.602Z',
+            '6.12.0-beta.1': '2026-02-17T19:44:18.872Z',
+            '6.12.0-beta.3': '2026-03-25T21:10:01.406Z',
+            '6.11.1': '2026-03-27T18:30:03.295Z',
+            '6.8.4': '2026-03-27T18:33:51.904Z',
+            '6.12.0': '2026-03-31T22:18:12.452Z',
+            '7.0.0-beta.1': '2026-04-01T01:15:02.043Z',
+            '7.0.0-alpha.1': '2026-04-01T20:38:07.383Z',
+            '7.1.0-alpha.1': '2026-04-08T20:43:50.777Z',
+            '7.1.0-alpha.2': '2026-04-15T20:47:34.803Z',
+            '7.0.0': '2026-05-12T03:06:57.388Z',
+            '7.1.0-beta.1': '2026-05-12T17:52:31.003Z',
+          });
+        }
+
+        if (command === 'dist-tags') {
+          return JSON.stringify({
+            old: '6.8.4',
+            lts: '6.12.0',
+            beta: '7.1.0-beta.1',
+            alpha: '7.1.0-alpha.5',
+            latest: '7.0.0',
+          });
+        }
+      },
+    },
+  };
+});
+
+describe('getLatestVersion function', function () {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('can get the latest in range', async function () {
+    const result = await getLatestVersion('ember-soruce', '~6.8.1');
+    expect(result).to.equal('6.8.4');
+  });
+
+  it('does not update to the latest range version if it is outside of our 1 week window', async function () {
+    const date = new Date('2026-03-29');
+    vi.setSystemTime(date);
+    const result = await getLatestVersion('ember-soruce', '~6.8.1');
+    expect(result).to.equal('6.8.3');
+  });
+
+  it('gives you the beta version if you ask for the beta tag', async function () {
+    const result = await getLatestVersion('ember-soruce', '~6.8.1', 'beta');
+    expect(result).to.equal('7.1.0-beta.1');
+  });
+});


### PR DESCRIPTION
This is to prevent us from forcing an update to a compromised npm package 👍 

~I will mark this as a major since it has a fundemental difference in its behaviour even though the API hasn't changed~

Edit: we're still pre 1.0 so I've marked this as an enhancement because technically this is a breaking change with pre-1.0 semver 🫠 🙈 